### PR TITLE
Retain window to fix test. Do not debug while testing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.8.1 (Next)
 
 * Your contribution here.
+* [#67](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/67): Retain window to fix test. Do not debug while testing. - [@babbage](https://github.com/babbage).
 
 ### 0.8.0 (11.10.2017)
 

--- a/FBSnapshotsViewer.xcodeproj/xcshareddata/xcschemes/FBSnapshotsViewer.xcscheme
+++ b/FBSnapshotsViewer.xcodeproj/xcshareddata/xcschemes/FBSnapshotsViewer.xcscheme
@@ -24,8 +24,9 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -56,6 +57,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/FBSnapshotsViewerTests/TestResultsWireframeSpec.swift
+++ b/FBSnapshotsViewerTests/TestResultsWireframeSpec.swift
@@ -12,6 +12,8 @@ import Nimble
 @testable import FBSnapshotsViewer
 
 class TestResultsWireframeSpec: QuickSpec {
+    var window: NSWindow?
+    
     override func spec() {
         var wireframe: TestResultsWireframe!
 
@@ -28,8 +30,8 @@ class TestResultsWireframeSpec: QuickSpec {
                 rect = NSRect(x: 0, y: 0, width: 300, height: 300)
                 view = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 200))
                 view.wantsLayer = true
-                let window = NSWindow(contentRect: rect, styleMask: NSWindowStyleMask.borderless, backing: .retained, defer: false)
-                window.contentView?.addSubview(view)
+                self.window = NSWindow(contentRect: rect, styleMask: NSWindowStyleMask.borderless, backing: .retained, defer: false)
+                self.window?.contentView?.addSubview(view)
             }
 
             it("initializes the module") {


### PR DESCRIPTION
Disabling debugging while testing enables tests to be run from Xcode as well as via the command line. This commit also fixes a test that was failing because the view was being added to a window that was being deallocated before the test condition was examined.