### PR TITLE
Fix error and add step to contributor text.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.8.1 (Next)
 
 * Your contribution here.
+* [#68](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/68): Fix error and add step to contributor text. - [@babbage](https://github.com/babbage).
 
 ### 0.8.0 (11.10.2017)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,18 @@ git remote add upstream https://github.com/Antondomashnev/FBSnapshotsViewer.git
 
 ### Bundle Install and Test
 
+Install [Bundler](http://bundler.io) if you have not previously done so on your development machine.
+
+```
+gem install bundler
+```
+
 Ensure that you can build the project and run tests.
 
 ```
 bundle install
 bundle exec pod install
-bundle exec fastlane osx test
+bundle exec fastlane mac test
 ```
 
 ## Contribute Code


### PR DESCRIPTION
Modifies fastlane name in Contributor instructions to the correct "mac" rather than "osx". Also adds a step to the contributor instructions regarding the installation of Bundler if you have not done this previously on your development machine.