### PR TITLE
Replace Swap with Accept and Accept All.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.8.1 (Next)
 
 * Your contribution here.
+* [#69](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/69): Replace Swap with Accept and Accept All. - [@babbage](https://github.com/babbage).
 
 ### 0.8.0 (11.10.2017)
 

--- a/FBSnapshotsViewer.xcodeproj/project.pbxproj
+++ b/FBSnapshotsViewer.xcodeproj/project.pbxproj
@@ -147,8 +147,8 @@
 		6DBD6C541EAD4B2B006F14DC /* ApplicationTestLogFilesListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD6C531EAD4B2B006F14DC /* ApplicationTestLogFilesListener.swift */; };
 		6DBD99D91E7AB31B00E1714E /* NonRecursiveFolderEventsListenerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD99D81E7AB31B00E1714E /* NonRecursiveFolderEventsListenerSpec.swift */; };
 		6DBD99DB1E7AB3D400E1714E /* FileWatcherFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD99DA1E7AB3D400E1714E /* FileWatcherFactory.swift */; };
-		6DCCEF0C1F02F60700523B47 /* SnapshotTestResultSwapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCCEF0B1F02F60700523B47 /* SnapshotTestResultSwapper.swift */; };
-		6DCCEF0E1F02F64800523B47 /* SnapshotTestResultSwapperSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCCEF0D1F02F64800523B47 /* SnapshotTestResultSwapperSpec.swift */; };
+		6DCCEF0C1F02F60700523B47 /* SnapshotTestResultAcceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCCEF0B1F02F60700523B47 /* SnapshotTestResultAcceptor.swift */; };
+		6DCCEF0E1F02F64800523B47 /* SnapshotTestResultAcceptorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCCEF0D1F02F64800523B47 /* SnapshotTestResultAcceptorSpec.swift */; };
 		6DD1AEA51F08093E002FCA82 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD1AEA41F08093E002FCA82 /* ImageCache.swift */; };
 		6DD1AEA71F080968002FCA82 /* Nuke+ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD1AEA61F080968002FCA82 /* Nuke+ImageCache.swift */; };
 		6DDFBD8D1E63268300DFC0A4 /* FolderEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDFBD8C1E63268300DFC0A4 /* FolderEvent.swift */; };
@@ -328,8 +328,8 @@
 		6DBD6C531EAD4B2B006F14DC /* ApplicationTestLogFilesListener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationTestLogFilesListener.swift; sourceTree = "<group>"; };
 		6DBD99D81E7AB31B00E1714E /* NonRecursiveFolderEventsListenerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonRecursiveFolderEventsListenerSpec.swift; sourceTree = "<group>"; };
 		6DBD99DA1E7AB3D400E1714E /* FileWatcherFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileWatcherFactory.swift; sourceTree = "<group>"; };
-		6DCCEF0B1F02F60700523B47 /* SnapshotTestResultSwapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestResultSwapper.swift; sourceTree = "<group>"; };
-		6DCCEF0D1F02F64800523B47 /* SnapshotTestResultSwapperSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestResultSwapperSpec.swift; sourceTree = "<group>"; };
+		6DCCEF0B1F02F60700523B47 /* SnapshotTestResultAcceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestResultAcceptor.swift; sourceTree = "<group>"; };
+		6DCCEF0D1F02F64800523B47 /* SnapshotTestResultAcceptorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestResultAcceptorSpec.swift; sourceTree = "<group>"; };
 		6DD1AEA41F08093E002FCA82 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		6DD1AEA61F080968002FCA82 /* Nuke+ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Nuke+ImageCache.swift"; sourceTree = "<group>"; };
 		6DDFBD8C1E63268300DFC0A4 /* FolderEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FolderEvent.swift; sourceTree = "<group>"; };
@@ -577,7 +577,7 @@
 				6D14776C1EFED78D0070EFEC /* BuildCreatorSpec.swift */,
 				6D1477721EFEE7D00070EFEC /* FBReferenceImageDirectoryURLExtractorSpec.swift */,
 				6D1477741EFEEDB30070EFEC /* ApplicationSnapshotTestResultFileWatcherUpdateHandlerSpec.swift */,
-				6DCCEF0D1F02F64800523B47 /* SnapshotTestResultSwapperSpec.swift */,
+				6DCCEF0D1F02F64800523B47 /* SnapshotTestResultAcceptorSpec.swift */,
 				6D57D3E31F31A9CD007FDBAE /* StringStripSpec.swift */,
 				6D942D521F40E544009984C4 /* TestClassPathExtractorpecSpec.swift */,
 				6D942D561F40FE1D009984C4 /* TestLineNumberExtractorSpec.swift */,
@@ -644,7 +644,7 @@
 				6D942D541F40FC2E009984C4 /* TestLineNumberExtractor.swift */,
 				6D14776A1EFED5500070EFEC /* BuildCreator.swift */,
 				6D14776E1EFEDF5A0070EFEC /* ApplicationSnapshotTestResultFileWatcherUpdateHandler.swift */,
-				6DCCEF0B1F02F60700523B47 /* SnapshotTestResultSwapper.swift */,
+				6DCCEF0B1F02F60700523B47 /* SnapshotTestResultAcceptor.swift */,
 				6D5EB5421F43999A0055C356 /* TestNameExtractor.swift */,
 				6D5EB5441F4399A70055C356 /* TestClassNameExtractor.swift */,
 			);
@@ -1158,7 +1158,7 @@
 				6D3000431EBFBE14005B6103 /* PreferencesController.swift in Sources */,
 				6D5F913C1E4F6D4700C6E5BF /* FolderEventsListenerFactory.swift in Sources */,
 				6D89B9541EF088B600865C5F /* TestResultsDiffMode.swift in Sources */,
-				6DCCEF0C1F02F60700523B47 /* SnapshotTestResultSwapper.swift in Sources */,
+				6DCCEF0C1F02F60700523B47 /* SnapshotTestResultAcceptor.swift in Sources */,
 				6DA1BF991E7755110017D47B /* Storyboards.swift in Sources */,
 				6DE3477E1E47D9DF004147DF /* MenuInteractorIO.swift in Sources */,
 				6DBD6C501EACF1B0006F14DC /* DerivedDataFolder.swift in Sources */,
@@ -1216,7 +1216,7 @@
 				6D1477731EFEE7D00070EFEC /* FBReferenceImageDirectoryURLExtractorSpec.swift in Sources */,
 				6D130B6D1EC8E82B00E9642A /* ConfigurationSpec.swift in Sources */,
 				6D3BA5651E6E07AA00CAD4EE /* MenuPresenterSpec.swift in Sources */,
-				6DCCEF0E1F02F64800523B47 /* SnapshotTestResultSwapperSpec.swift in Sources */,
+				6DCCEF0E1F02F64800523B47 /* SnapshotTestResultAcceptorSpec.swift in Sources */,
 				6D42C93E1EB275B6003744BF /* MenuWireframeSpec.swift in Sources */,
 				6D342CE21EBBDFDF006EEBEC /* AppleInterfaceModeSpec.swift in Sources */,
 				6D12F4721E81758500AA4727 /* TestResultsControllerSpec.swift in Sources */,

--- a/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
+++ b/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
@@ -1,5 +1,5 @@
 //
-//  SnapshotTestResultSwapper.swift
+//  SnapshotTestResultAcceptor.swift
 //  FBSnapshotsViewer
 //
 //  Created by Anton Domashnev on 27.06.17.
@@ -9,14 +9,14 @@
 import Foundation
 import Nuke
 
-enum SnapshotTestResultSwapperError: Error {
-    case canNotBeSwapped(testResult: SnapshotTestResult)
+enum SnapshotTestResultAcceptorError: Error {
+    case canNotBeAccepted(testResult: SnapshotTestResult)
     case nonRetinaImages(testResult: SnapshotTestResult)
     case notExistedRecordedImage(testResult: SnapshotTestResult)
     case canNotPerformFileManagerOperation(testResult: SnapshotTestResult, underlyingError: Error)
 }
 
-class SnapshotTestResultSwapper {
+class SnapshotTestResultAcceptor {
     private let fileManager: FileManager
     private let imageCache: ImageCache
     
@@ -29,7 +29,7 @@ class SnapshotTestResultSwapper {
     
     private func buildRecordedImageURL(from imagePath: String, of testResult: SnapshotTestResult) throws -> URL {
         guard let failedImageSizeSuffixRange = imagePath.range(of: "@\\d{1}x", options: .regularExpression) else {
-                throw SnapshotTestResultSwapperError.nonRetinaImages(testResult: testResult)
+                throw SnapshotTestResultAcceptorError.nonRetinaImages(testResult: testResult)
         }
         let failedImageSizeSuffix = imagePath.substring(with: failedImageSizeSuffixRange)
         let recordedImageURLs = testResult.build.fbReferenceImageDirectoryURLs.flatMap { fbReferenceImageDirectoryURL -> URL? in
@@ -37,23 +37,23 @@ class SnapshotTestResultSwapper {
             return fileManager.fileExists(atPath: url.path) ? url : nil
         }
         guard let url = recordedImageURLs.first else {
-            throw SnapshotTestResultSwapperError.notExistedRecordedImage(testResult: testResult)
+            throw SnapshotTestResultAcceptorError.notExistedRecordedImage(testResult: testResult)
         }
         return url
     }
     
     // MARK: - Interface
     
-    func canSwap(_ testResult: SnapshotTestResult) -> Bool {
+    func canAccept(_ testResult: SnapshotTestResult) -> Bool {
         if case SnapshotTestResult.failed(_, _, _, _, _) = testResult {
             return true
         }
         return false
     }
     
-    func swap(_ testResult: SnapshotTestResult) throws -> SnapshotTestResult {
-        guard case let SnapshotTestResult.failed(testInformation, _, _, failedImagePath, build) = testResult, canSwap(testResult) else {
-            throw SnapshotTestResultSwapperError.canNotBeSwapped(testResult: testResult)
+    func accept(_ testResult: SnapshotTestResult) throws -> SnapshotTestResult {
+        guard case let SnapshotTestResult.failed(testInformation, _, _, failedImagePath, build) = testResult, canAccept(testResult) else {
+            throw SnapshotTestResultAcceptorError.canNotBeAccepted(testResult: testResult)
         }
         let failedImageURL = URL(fileURLWithPath: failedImagePath, isDirectory: false)
         do {
@@ -63,7 +63,7 @@ class SnapshotTestResultSwapper {
             return SnapshotTestResult.recorded(testInformation: testInformation, referenceImagePath: recordedImageURL.path, build: build)
         }
         catch let error {
-            throw SnapshotTestResultSwapperError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)
+            throw SnapshotTestResultAcceptorError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)
         }
     }
 }

--- a/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractor.swift
+++ b/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractor.swift
@@ -10,13 +10,13 @@ import Foundation
 import Cocoa
 
 enum TestResultsInteractorError: Error {
-    case canNotSwapNotExistedTestResult
+    case canNotAcceptNotExistedTestResult
 }
 
 class TestResultsInteractorBuilder {
     var externalViewers: ExternalViewers = ExternalViewers()
     var processLauncher: ProcessLauncher = ProcessLauncher()
-    var swapper: SnapshotTestResultSwapper = SnapshotTestResultSwapper()
+    var acceptor: SnapshotTestResultAcceptor = SnapshotTestResultAcceptor()
     var pasteboard: Pasteboard = NSPasteboard.general()
     var testResults: [SnapshotTestResult] = []
     
@@ -31,7 +31,7 @@ class TestResultsInteractor {
     fileprivate let xcodeViewer: ExternalViewer.Type
     fileprivate let kaleidoscopeViewer: ExternalViewer.Type
     fileprivate let processLauncher: ProcessLauncher
-    fileprivate let swapper: SnapshotTestResultSwapper
+    fileprivate let acceptor: SnapshotTestResultAcceptor
     fileprivate let pasteboard: Pasteboard
     var testResults: [SnapshotTestResult]
     
@@ -42,7 +42,7 @@ class TestResultsInteractor {
         self.kaleidoscopeViewer = builder.externalViewers.kaleidoscope
         self.xcodeViewer = builder.externalViewers.xcode
         self.processLauncher = builder.processLauncher
-        self.swapper = builder.swapper
+        self.acceptor = builder.acceptor
         self.pasteboard = builder.pasteboard
     }
 }
@@ -52,7 +52,7 @@ extension TestResultsInteractor: TestResultsInteractorInput {
     
     private func replace(testResult: SnapshotTestResult, with newTestResult: SnapshotTestResult) throws {
         guard let indexOfTestResult = testResults.index(of: testResult) else {
-            throw TestResultsInteractorError.canNotSwapNotExistedTestResult
+            throw TestResultsInteractorError.canNotAcceptNotExistedTestResult
         }
         testResults[indexOfTestResult] = newTestResult
     }
@@ -75,16 +75,16 @@ extension TestResultsInteractor: TestResultsInteractorInput {
         xcodeViewer.view(snapshotTestResult: testResult, using: processLauncher)
     }
     
-    func swap(testResult: SnapshotTestResult) {
-        if !swapper.canSwap(testResult) {
+    func accept(testResult: SnapshotTestResult) {
+        if !acceptor.canAccept(testResult) {
             return
         }
         do {
-            let swappedTestResult = try swapper.swap(testResult)
-            try replace(testResult: testResult, with: swappedTestResult)
+            let acceptedTestResult = try acceptor.accept(testResult)
+            try replace(testResult: testResult, with: acceptedTestResult)
         }
         catch let error {
-            output?.didFailToSwap(testResult: testResult, with: error)
+            output?.didFailToAccept(testResult: testResult, with: error)
         }
     }
     

--- a/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractorIO.swift
+++ b/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractorIO.swift
@@ -12,10 +12,10 @@ protocol TestResultsInteractorInput: class, AutoMockable {
     var testResults: [SnapshotTestResult] { get }
     func openInKaleidoscope(testResult: SnapshotTestResult)
     func openInXcode(testResult: SnapshotTestResult)
-    func swap(testResult: SnapshotTestResult)
+    func accept(testResult: SnapshotTestResult)
     func copy(testResult: SnapshotTestResult)
 }
 
 protocol TestResultsInteractorOutput: class, AutoMockable {
-    func didFailToSwap(testResult: SnapshotTestResult, with error: Error)
+    func didFailToAccept(testResult: SnapshotTestResult, with error: Error)
 }

--- a/FBSnapshotsViewer/Test Results/Presenter/TestResultDisplayInfo.swift
+++ b/FBSnapshotsViewer/Test Results/Presenter/TestResultDisplayInfo.swift
@@ -23,16 +23,16 @@ struct TestResultInformationDisplayInfo: AutoEquatable {
 
 struct TestResultDisplayInfoOptions: OptionSet {
     let rawValue: Int
-    static let canBeSwapped = TestResultDisplayInfoOptions(rawValue: 1 << 0)
+    static let canBeAccepted = TestResultDisplayInfoOptions(rawValue: 1 << 0)
     static let canBeViewedInKaleidoscope = TestResultDisplayInfoOptions(rawValue: 1 << 1)
     static let canBeViewedInXcode = TestResultDisplayInfoOptions(rawValue: 1 << 2)
     static let canBeCopied = TestResultDisplayInfoOptions(rawValue: 1 << 3)
 }
 
 extension TestResultDisplayInfoOptions {
-    static func availableOptions(for testResult: SnapshotTestResult, externalViewers: ExternalViewers = ExternalViewers(), swapper: SnapshotTestResultSwapper = SnapshotTestResultSwapper()) -> TestResultDisplayInfoOptions {
+    static func availableOptions(for testResult: SnapshotTestResult, externalViewers: ExternalViewers = ExternalViewers(), acceptor: SnapshotTestResultAcceptor = SnapshotTestResultAcceptor()) -> TestResultDisplayInfoOptions {
         var availableOptions: TestResultDisplayInfoOptions = [TestResultDisplayInfoOptions.canBeCopied]
-        if swapper.canSwap(testResult) { availableOptions = availableOptions.union(.canBeSwapped) }
+        if acceptor.canAccept(testResult) { availableOptions = availableOptions.union(.canBeAccepted) }
         if externalViewers.xcode.isAvailable() && externalViewers.xcode.canView(snapshotTestResult: testResult) { availableOptions = availableOptions.union(.canBeViewedInXcode) }
         if externalViewers.kaleidoscope.isAvailable() && externalViewers.kaleidoscope.canView(snapshotTestResult: testResult) { availableOptions = availableOptions.union(.canBeViewedInKaleidoscope) }
         return availableOptions
@@ -55,8 +55,8 @@ struct TestResultDisplayInfo: AutoEquatable {
         return testInformation.testContext
     }
     
-    var canBeSwapped: Bool {
-        return options.contains(.canBeSwapped)
+    var canBeAccepted: Bool {
+        return options.contains(.canBeAccepted)
     }
     
     var canBeViewedInKaleidoscope: Bool {
@@ -71,10 +71,10 @@ struct TestResultDisplayInfo: AutoEquatable {
         return options.contains(.canBeCopied)
     }
 
-    init(testResult: SnapshotTestResult, swapper: SnapshotTestResultSwapper = SnapshotTestResultSwapper(), externalViewers: ExternalViewers = ExternalViewers()) {
+    init(testResult: SnapshotTestResult, acceptor: SnapshotTestResultAcceptor = SnapshotTestResultAcceptor(), externalViewers: ExternalViewers = ExternalViewers()) {
         self.testResult = testResult
         self.testInformation = TestResultInformationDisplayInfo(testResultInformation: testResult.testInformation)
-        self.options = TestResultDisplayInfoOptions.availableOptions(for: testResult, externalViewers: externalViewers, swapper: swapper)
+        self.options = TestResultDisplayInfoOptions.availableOptions(for: testResult, externalViewers: externalViewers, acceptor: acceptor)
         switch testResult {
         case let .recorded(_, referenceImagePath, _):
             self.referenceImageURL = URL(fileURLWithPath: referenceImagePath)

--- a/FBSnapshotsViewer/Test Results/Presenter/TestResultsPresenter.swift
+++ b/FBSnapshotsViewer/Test Results/Presenter/TestResultsPresenter.swift
@@ -42,9 +42,9 @@ extension TestResultsPresenter: TestResultsModuleInterface {
         updateUserInterface()
     }
     
-    func swap(_ testResults: [TestResultDisplayInfo]) {
+    func accept(_ testResults: [TestResultDisplayInfo]) {
         for testResultInfo in testResults {
-            interactor?.swap(testResult: testResultInfo.testResult)
+            interactor?.accept(testResult: testResultInfo.testResult)
         }
         updateUserInterface()
     }
@@ -55,11 +55,11 @@ extension TestResultsPresenter: TestResultsModuleInterface {
 }
 
 extension TestResultsPresenter: TestResultsInteractorOutput {
-    func didFailToSwap(testResult: SnapshotTestResult, with error: Error) {
-        let failToSwapAlert = NSAlert()
-        failToSwapAlert.addButton(withTitle: "Ok")
-        failToSwapAlert.alertStyle = .critical
-        failToSwapAlert.messageText = "Ops, swap can not be done. \(error.localizedDescription). Please report an issue https://github.com/Antondomashnev/FBSnapshotsViewer/issues/new"
-        failToSwapAlert.runModal()
+    func didFailToAccept(testResult: SnapshotTestResult, with error: Error) {
+        let failToAcceptAlert = NSAlert()
+        failToAcceptAlert.addButton(withTitle: "Ok")
+        failToAcceptAlert.alertStyle = .critical
+        failToAcceptAlert.messageText = "Ops, accept can not be done. \(error.localizedDescription). Please report an issue https://github.com/Antondomashnev/FBSnapshotsViewer/issues/new"
+        failToAcceptAlert.runModal()
     }
 }

--- a/FBSnapshotsViewer/Test Results/Presenter/TestResultsSectionDisplayInfo.swift
+++ b/FBSnapshotsViewer/Test Results/Presenter/TestResultsSectionDisplayInfo.swift
@@ -35,8 +35,8 @@ struct TestResultsSectionDisplayInfo: AutoEquatable {
     let titleInfo: TestResultsSectionTitleDisplayInfo
     let itemInfos: [TestResultDisplayInfo]
     
-    var hasItemsToSwap: Bool {
-        return itemInfos.index { $0.canBeSwapped } != nil ? true : false
+    var hasItemsToAccept: Bool {
+        return itemInfos.index { $0.canBeAccepted } != nil ? true : false
     }
     
     init(title: TestResultsSectionTitleDisplayInfo, items: [TestResultDisplayInfo] = []) {

--- a/FBSnapshotsViewer/Test Results/TestResultsModuleInterface.swift
+++ b/FBSnapshotsViewer/Test Results/TestResultsModuleInterface.swift
@@ -13,6 +13,6 @@ protocol TestResultsModuleInterface: class, AutoMockable {
     func openInKaleidoscope(testResultDisplayInfo: TestResultDisplayInfo)
     func openInXcode(testResultDisplayInfo: TestResultDisplayInfo)
     func selectDiffMode(_ diffMode: TestResultsDiffMode)
-    func swap(_ testResults: [TestResultDisplayInfo])
+    func accept(_ testResults: [TestResultDisplayInfo])
     func copy(testResultDisplayInfo: TestResultDisplayInfo)
 }

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultCell.swift
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultCell.swift
@@ -12,7 +12,7 @@ import Nuke
 protocol TestResultCellDelegate: class, AutoMockable {
     func testResultCell(_ cell: TestResultCell, viewInXcodeButtonClicked: NSButton)
     func testResultCell(_ cell: TestResultCell, viewInKaleidoscopeButtonClicked: NSButton)
-    func testResultCell(_ cell: TestResultCell, swapSnapshotsButtonClicked: NSButton)
+    func testResultCell(_ cell: TestResultCell, acceptSnapshotsButtonClicked: NSButton)
     func testResultCell(_ cell: TestResultCell, copySnapshotButtonClicked: NSButton)
 }
 
@@ -24,7 +24,7 @@ class TestResultCell: NSCollectionViewItem {
     @IBOutlet private weak var actionsContainerView: NSView!
     @IBOutlet private weak var viewInKaleidoscopeButton: NSButton!
     @IBOutlet private weak var viewInXcodeButton: NSButton!
-    @IBOutlet private weak var swapSnapshotsButton: NSButton!
+    @IBOutlet private weak var acceptSnapshotsButton: NSButton!
     @IBOutlet private weak var copySnapshotButton: NSButton!
     
     @IBOutlet private weak var imagesContainerView: NSView!
@@ -99,7 +99,7 @@ class TestResultCell: NSCollectionViewItem {
         else {
             failedImageView.image = nil
         }
-        swapSnapshotsButton.isHidden = !testResult.canBeSwapped
+        acceptSnapshotsButton.isHidden = !testResult.canBeAccepted
         viewInKaleidoscopeButton.isHidden = !testResult.canBeViewedInKaleidoscope
         viewInXcodeButton.isHidden = !testResult.canBeViewedInXcode
         copySnapshotButton.isHidden = !testResult.canBeCopied
@@ -137,7 +137,7 @@ class TestResultCell: NSCollectionViewItem {
         delegate?.testResultCell(self, viewInKaleidoscopeButtonClicked: sender)
     }
     
-    @objc @IBAction func swapSnapshotsButtonClicked(_ sender: NSButton) {
-        delegate?.testResultCell(self, swapSnapshotsButtonClicked: sender)
+    @objc @IBAction func acceptSnapshotsButtonClicked(_ sender: NSButton) {
+        delegate?.testResultCell(self, acceptSnapshotsButtonClicked: sender)
     }
 }

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultCell.xib
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13178.6" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13178.6"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -191,13 +191,13 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dTc-pr-6Mk">
-                            <rect key="frame" x="200" y="0.0" width="43" height="17"/>
-                            <buttonCell key="cell" type="inline" title="Swap" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="erZ-Db-LCI">
+                            <rect key="frame" x="200" y="0.0" width="52" height="17"/>
+                            <buttonCell key="cell" type="inline" title="Accept" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="erZ-Db-LCI">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="smallSystemBold"/>
                             </buttonCell>
                             <connections>
-                                <action selector="swapSnapshotsButtonClicked:" target="i7H-GG-lM3" id="sNe-PT-tvr"/>
+                                <action selector="acceptSnapshotsButtonClicked:" target="i7H-GG-lM3" id="9Sg-cx-JnE"/>
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="T5h-WQ-msk">
@@ -248,6 +248,7 @@
         </customView>
         <collectionViewItem nibName="TestResultCell" id="i7H-GG-lM3" customClass="TestResultCell" customModule="FBSnapshotsViewer" customModuleProvider="target">
             <connections>
+                <outlet property="acceptSnapshotsButton" destination="dTc-pr-6Mk" id="XcZ-34-QUG"/>
                 <outlet property="actionsContainerView" destination="AHf-ta-nvJ" id="ggA-yn-13p"/>
                 <outlet property="copySnapshotButton" destination="ywy-Aa-jQX" id="Uwx-dp-kHu"/>
                 <outlet property="diffContainerView" destination="HvH-e1-A4r" id="Ydb-cW-xPt"/>
@@ -259,7 +260,6 @@
                 <outlet property="referenceImageView" destination="K85-1M-wcy" id="UtW-Gp-pOZ"/>
                 <outlet property="separatorView" destination="Xdr-DA-S5B" id="axP-xd-ghd"/>
                 <outlet property="splitContainerView" destination="oaS-Kh-fqd" id="ID4-fk-Axc"/>
-                <outlet property="swapSnapshotsButton" destination="dTc-pr-6Mk" id="rYx-Iv-mfX"/>
                 <outlet property="testInfoContainerView" destination="YEn-VX-jtO" id="RRJ-ht-Nth"/>
                 <outlet property="testNameLabel" destination="MCk-nZ-jTQ" id="4DF-7O-GL0"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="t7t-hF-Vsm"/>

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultsController.swift
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultsController.swift
@@ -66,12 +66,12 @@ extension TestResultsController: TestResultCellDelegate {
         openIn(eventHandler.openInKaleidoscope, from: cell)
     }
     
-    func testResultCell(_ cell: TestResultCell, swapSnapshotsButtonClicked: NSButton) {
+    func testResultCell(_ cell: TestResultCell, acceptSnapshotsButtonClicked: NSButton) {
         guard let testResultInfo = findTestResultInfo(for: cell) else {
-            assertionFailure("Unexpected TestResultCellDelegate callback about swap snapshots button click")
+            assertionFailure("Unexpected TestResultCellDelegate callback about accept snapshots button click")
             return
         }
-        eventHandler.swap([testResultInfo.info])
+        eventHandler.accept([testResultInfo.info])
         collectionView.reloadSections(IndexSet(integer: testResultInfo.indexPath.section))
     }
     
@@ -99,12 +99,12 @@ extension TestResultsController: TestResultsHeaderDelegate {
         return (sectionInfos[headerIndexPath.section], headerIndexPath)
     }
     
-    func testResultsHeader(_ header: TestResultsHeader, swapSnapshotsButtonClicked: NSButton) {
+    func testResultsHeader(_ header: TestResultsHeader, acceptSnapshotsButtonClicked: NSButton) {
         guard let testResultsSectionInfo = findTestResultsSectionDisplayInfo(for: header) else {
-            assertionFailure("Unexpected TestResultsHeaderDelegate callback about swap snapshots button click")
+            assertionFailure("Unexpected TestResultsHeaderDelegate callback about accept snapshots button click")
             return
         }
-        eventHandler.swap(testResultsSectionInfo.info.itemInfos)
+        eventHandler.accept(testResultsSectionInfo.info.itemInfos)
         collectionView.reloadSections(IndexSet(integer: testResultsSectionInfo.indexPath.section))
     }
 }

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultsHeader.swift
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultsHeader.swift
@@ -9,7 +9,7 @@
 import AppKit
 
 protocol TestResultsHeaderDelegate: class, AutoMockable {
-    func testResultsHeader(_ header: TestResultsHeader, swapSnapshotsButtonClicked: NSButton)
+    func testResultsHeader(_ header: TestResultsHeader, acceptSnapshotsButtonClicked: NSButton)
 }
 
 class TestResultsHeader: NSView, NSCollectionViewSectionHeaderView {
@@ -19,7 +19,7 @@ class TestResultsHeader: NSView, NSCollectionViewSectionHeaderView {
     
     @IBOutlet private weak var contextLabel: NSTextField!
     @IBOutlet private weak var dateLabel: NSTextField!
-    @IBOutlet private weak var swapSnapshotsButton: NSButton!
+    @IBOutlet private weak var acceptSnapshotsButton: NSButton!
     
     // MARK: - Helpers
     
@@ -33,13 +33,13 @@ class TestResultsHeader: NSView, NSCollectionViewSectionHeaderView {
     func configure(with sectionInfo: TestResultsSectionDisplayInfo, appleInterfaceMode: AppleInterfaceMode = AppleInterfaceMode()) {
         contextLabel.stringValue = sectionInfo.titleInfo.title
         dateLabel.stringValue = sectionInfo.titleInfo.timeAgo
-        swapSnapshotsButton.isHidden = !sectionInfo.hasItemsToSwap
+        acceptSnapshotsButton.isHidden = !sectionInfo.hasItemsToAccept
         configureTitleLabelsColorScheme(for: appleInterfaceMode)
     }
     
     // MARK: - Actions
     
-    @objc @IBAction func swapSnapshotsButtonClicked(_ sender: NSButton) {
-        delegate?.testResultsHeader(self, swapSnapshotsButtonClicked: sender)
+    @objc @IBAction func acceptSnapshotsButtonClicked(_ sender: NSButton) {
+        delegate?.testResultsHeader(self, acceptSnapshotsButtonClicked: sender)
     }
 }

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultsHeader.xib
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultsHeader.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13122.17" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13122.17"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -31,13 +31,13 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s7w-tW-bNz">
-                    <rect key="frame" x="681" y="6" width="43" height="17"/>
-                    <buttonCell key="cell" type="inline" title="Swap" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="wIK-4A-ekf">
+                    <rect key="frame" x="655" y="6" width="69" height="17"/>
+                    <buttonCell key="cell" type="inline" title="Accept All" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="wIK-4A-ekf">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystemBold"/>
                     </buttonCell>
                     <connections>
-                        <action selector="swapSnapshotsButtonClicked:" target="c22-O7-iKe" id="eLv-Xi-qAJ"/>
+                        <action selector="acceptSnapshotsButtonClicked:" target="c22-O7-iKe" id="eLv-Xi-qAJ"/>
                     </connections>
                 </button>
             </subviews>
@@ -51,9 +51,9 @@
                 <constraint firstItem="vTy-Nb-VrP" firstAttribute="firstBaseline" secondItem="A8U-0D-fPv" secondAttribute="baseline" id="lno-wT-Abe"/>
             </constraints>
             <connections>
+                <outlet property="acceptSnapshotsButton" destination="s7w-tW-bNz" id="saF-o0-jsz"/>
                 <outlet property="contextLabel" destination="vTy-Nb-VrP" id="icZ-F5-nGC"/>
                 <outlet property="dateLabel" destination="A8U-0D-fPv" id="njE-Ug-odu"/>
-                <outlet property="swapSnapshotsButton" destination="s7w-tW-bNz" id="saF-o0-jsz"/>
             </connections>
         </customView>
     </objects>

--- a/FBSnapshotsViewerTests/SnapshotTestResultAcceptorSpec.swift
+++ b/FBSnapshotsViewerTests/SnapshotTestResultAcceptorSpec.swift
@@ -1,5 +1,5 @@
 //
-//  SnapshotTestResultSwapperSpec.swift
+//  SnapshotTestResultAcceptorSpec.swift
 //  FBSnapshotsViewerTests
 //
 //  Created by Anton Domashnev on 27.06.17.
@@ -11,8 +11,8 @@ import Nimble
 
 @testable import FBSnapshotsViewer
 
-class SnapshotTestResultSwapper_MockFileManager: FileManager {
-    enum SnapshotTestResultSwapper_MockFileManagerError: Error {
+class SnapshotTestResultAcceptor_MockFileManager: FileManager {
+    enum SnapshotTestResultAcceptor_MockFileManagerError: Error {
         case sample
     }
     
@@ -22,7 +22,7 @@ class SnapshotTestResultSwapper_MockFileManager: FileManager {
     var copyItemThrows: Bool = false
     override func copyItem(at srcURL: URL, to dstURL: URL) throws {
         if copyItemThrows {
-            throw SnapshotTestResultSwapper_MockFileManagerError.sample
+            throw SnapshotTestResultAcceptor_MockFileManagerError.sample
         }
         copyItemCalled = true
         copyItemFromSourceURL = srcURL
@@ -34,7 +34,7 @@ class SnapshotTestResultSwapper_MockFileManager: FileManager {
     var removeItemThrows: Bool = false
     override func removeItem(at URL: URL) throws {
         if removeItemThrows {
-            throw SnapshotTestResultSwapper_MockFileManagerError.sample
+            throw SnapshotTestResultAcceptor_MockFileManagerError.sample
         }
         removeItemCalled = true
         removeItemAtURL = URL
@@ -48,23 +48,23 @@ class SnapshotTestResultSwapper_MockFileManager: FileManager {
     }
 }
 
-class SnapshotTestResultSwapperSpec: QuickSpec {
+class SnapshotTestResultAcceptorSpec: QuickSpec {
     override func spec() {
         var build: Build!
         var testInformation: SnapshotTestInformation!
         var imageCache: ImageCacheMock!
-        var swapper: SnapshotTestResultSwapper!
-        var fileManager: SnapshotTestResultSwapper_MockFileManager!
+        var acceptor: SnapshotTestResultAcceptor!
+        var fileManager: SnapshotTestResultAcceptor_MockFileManager!
         
         beforeEach {
             build = Build(date: Date(), applicationName: "MyApp", fbReferenceImageDirectoryURLs: [URL(fileURLWithPath: "/foo/bar", isDirectory: true)])
             testInformation = SnapshotTestInformation(testClassName: "Bar", testName: "Foo", testFilePath: "Bar/Foo.m", testLineNumber: 1)
-            fileManager = SnapshotTestResultSwapper_MockFileManager()
+            fileManager = SnapshotTestResultAcceptor_MockFileManager()
             imageCache = ImageCacheMock()
-            swapper = SnapshotTestResultSwapper(fileManager: fileManager, imageCache: imageCache)
+            acceptor = SnapshotTestResultAcceptor(fileManager: fileManager, imageCache: imageCache)
         }
         
-        describe(".swap") {
+        describe(".accept") {
             var testResult: SnapshotTestResult!
             
             context("given recorded snapshot test result") {
@@ -73,7 +73,7 @@ class SnapshotTestResultSwapperSpec: QuickSpec {
                 }
                 
                 it("throws error") {
-                    expect { try swapper.swap(testResult) }.to(throwError())
+                    expect { try acceptor.accept(testResult) }.to(throwError())
                 }
             }
             
@@ -85,7 +85,7 @@ class SnapshotTestResultSwapperSpec: QuickSpec {
                 }
                 
                 it("throws error") {
-                    expect { try swapper.swap(testResult) }.to(throwError())
+                    expect { try acceptor.accept(testResult) }.to(throwError())
                 }
             }
             
@@ -97,7 +97,7 @@ class SnapshotTestResultSwapperSpec: QuickSpec {
                     }
                     
                     it("throws error") {
-                        expect { try swapper.swap(testResult) }.to(throwError())
+                        expect { try acceptor.accept(testResult) }.to(throwError())
                     }
                 }
                 
@@ -115,14 +115,14 @@ class SnapshotTestResultSwapperSpec: QuickSpec {
                         }
                         
                         it("throws error") {
-                            expect { try swapper.swap(testResult) }.to(throwError())
+                            expect { try acceptor.accept(testResult) }.to(throwError())
                         }
                     }
                     
                     context("that exists") {
                         beforeEach {
                             fileManager.fileExistsReturnValue = true
-                            returnedTestResult = try? swapper.swap(testResult)
+                            returnedTestResult = try? acceptor.accept(testResult)
                         }
                         
                         it("removes current reference images from directory") {
@@ -140,7 +140,7 @@ class SnapshotTestResultSwapperSpec: QuickSpec {
                             expect(imageCache.invalidate_Called).to(beTrue())
                         }
                         
-                        it("returns swapped test result") {
+                        it("returns accepted test result") {
                             let expectedTestInformation = SnapshotTestInformation(testClassName: "DetailsViewController", testName: "testNormalState", testFilePath: "foo/DetailsViewController.m", testLineNumber: 1)
                             let expectedTestResult = SnapshotTestResult.recorded(testInformation: expectedTestInformation, referenceImagePath: "/foo/bar/DetailsViewController/testNormalState@2x.png", build: build)
                             expect(returnedTestResult).to(equal(expectedTestResult))
@@ -150,7 +150,7 @@ class SnapshotTestResultSwapperSpec: QuickSpec {
             }
         }
         
-        describe(".canSwap") {
+        describe(".canAccept") {
             var testResult: SnapshotTestResult!
             
             context("given recorded snapshot test result") {
@@ -159,7 +159,7 @@ class SnapshotTestResultSwapperSpec: QuickSpec {
                 }
                 
                 it("returns false") {
-                    expect(swapper.canSwap(testResult)).to(beFalse())
+                    expect(acceptor.canAccept(testResult)).to(beFalse())
                 }
             }
             
@@ -169,7 +169,7 @@ class SnapshotTestResultSwapperSpec: QuickSpec {
                 }
                 
                 it("returns true") {
-                    expect(swapper.canSwap(testResult)).to(beTrue())
+                    expect(acceptor.canAccept(testResult)).to(beTrue())
                 }
             }
         }

--- a/FBSnapshotsViewerTests/TestResultCellSpec.swift
+++ b/FBSnapshotsViewerTests/TestResultCellSpec.swift
@@ -56,14 +56,14 @@ class TestResultCellSpec: QuickSpec {
             }
         }
         
-        describe(".swapSnapshotsButtonClicked") {
+        describe(".acceptSnapshotsButtonClicked") {
             beforeEach {
-                cell.swapSnapshotsButtonClicked(NSButton(frame: NSRect.zero))
+                cell.acceptSnapshotsButtonClicked(NSButton(frame: NSRect.zero))
             }
             
             it("calls delegate") {
-                expect(delegate.testResultCell___swapSnapshotsButtonClicked_Called).to(beTrue())
-                expect(delegate.testResultCell___swapSnapshotsButtonClicked_ReceivedArguments?.cell).to(equal(cell))
+                expect(delegate.testResultCell___acceptSnapshotsButtonClicked_Called).to(beTrue())
+                expect(delegate.testResultCell___acceptSnapshotsButtonClicked_ReceivedArguments?.cell).to(equal(cell))
             }
         }
     }

--- a/FBSnapshotsViewerTests/TestResultDisplayInfoSpec.swift
+++ b/FBSnapshotsViewerTests/TestResultDisplayInfoSpec.swift
@@ -64,10 +64,10 @@ class TestResultDisplayInfo_MockKaleidoscopeViewer: ExternalViewer {
     }
 }
 
-class TestResultDisplayInfo_MockSnapshotTestResultSwapper: SnapshotTestResultSwapper {
-    var canSwapReturnValue: Bool = false
-    override func canSwap(_ testResult: SnapshotTestResult) -> Bool {
-        return canSwapReturnValue
+class TestResultDisplayInfo_MockSnapshotTestResultAcceptor: SnapshotTestResultAcceptor {
+    var canAcceptReturnValue: Bool = false
+    override func canAccept(_ testResult: SnapshotTestResult) -> Bool {
+        return canAcceptReturnValue
     }
 }
 
@@ -77,7 +77,7 @@ class TestResultDisplayInfoSpec: QuickSpec {
             var build: Build!
             var testInformation: SnapshotTestInformation!
             var testResult: SnapshotTestResult!
-            var swapper: TestResultDisplayInfo_MockSnapshotTestResultSwapper!
+            var acceptor: TestResultDisplayInfo_MockSnapshotTestResultAcceptor!
             var externalViewers: ExternalViewers!
             let kaleidoscopeViewer: TestResultDisplayInfo_MockKaleidoscopeViewer.Type = TestResultDisplayInfo_MockKaleidoscopeViewer.self
             let xcodeViewer: TestResultDisplayInfo_MockXcodeViewer.Type = TestResultDisplayInfo_MockXcodeViewer.self
@@ -88,7 +88,7 @@ class TestResultDisplayInfoSpec: QuickSpec {
             
             beforeEach {
                 externalViewers = ExternalViewers(xcodeViewer: xcodeViewer, kaleidoscopeViewer: kaleidoscopeViewer)
-                swapper = TestResultDisplayInfo_MockSnapshotTestResultSwapper()
+                acceptor = TestResultDisplayInfo_MockSnapshotTestResultAcceptor()
                 build = Build(date: Date(), applicationName: "FBSnapshotsViewer", fbReferenceImageDirectoryURLs: [URL(fileURLWithPath: "foo/bar", isDirectory: true)])
             }
             
@@ -128,7 +128,7 @@ class TestResultDisplayInfoSpec: QuickSpec {
                 }
             }
             
-            describe("canBeSwapped") {
+            describe("canBeAccepted") {
                 var displayInfo: TestResultDisplayInfo!
                 
                 beforeEach {
@@ -136,25 +136,25 @@ class TestResultDisplayInfoSpec: QuickSpec {
                     testResult = SnapshotTestResult.failed(testInformation: testInformation, referenceImagePath: "referenceImagePath.png", diffImagePath: "diffImagePath.png", failedImagePath: "failedImagePath.png", build: build)
                 }
                 
-                context("when swapper can swap given test result") {
+                context("when acceptor can accept given test result") {
                     beforeEach {
-                        swapper.canSwapReturnValue = true
-                        displayInfo = TestResultDisplayInfo(testResult: testResult, swapper: swapper)
+                        acceptor.canAcceptReturnValue = true
+                        displayInfo = TestResultDisplayInfo(testResult: testResult, acceptor: acceptor)
                     }
                     
-                    it("can be swapped") {
-                        expect(displayInfo.canBeSwapped).to(beTrue())
+                    it("can be accepted") {
+                        expect(displayInfo.canBeAccepted).to(beTrue())
                     }
                 }
                 
-                context("when swapper can not swap given test result") {
+                context("when acceptor can not accept given test result") {
                     beforeEach {
-                        swapper.canSwapReturnValue = false
-                        displayInfo = TestResultDisplayInfo(testResult: testResult, swapper: swapper)
+                        acceptor.canAcceptReturnValue = false
+                        displayInfo = TestResultDisplayInfo(testResult: testResult, acceptor: acceptor)
                     }
                     
-                    it("can not be swapped") {
-                        expect(displayInfo.canBeSwapped).to(beFalse())
+                    it("can not be accepted") {
+                        expect(displayInfo.canBeAccepted).to(beFalse())
                     }
                 }
             }

--- a/FBSnapshotsViewerTests/TestResultsControllerSpec.swift
+++ b/FBSnapshotsViewerTests/TestResultsControllerSpec.swift
@@ -104,12 +104,12 @@ class TestResultsControllerSpec: QuickSpec {
             }
         }
         
-        describe(".testResultCell:swapSnapshotsButtonClicked") {
+        describe(".testResultCell:acceptSnapshotsButtonClicked") {
             var cell: TestResultCell!
-            var swapSnapshotsButton: NSButton!
+            var acceptSnapshotsButton: NSButton!
             
             beforeEach {
-                swapSnapshotsButton = NSButton(frame: NSRect.zero)
+                acceptSnapshotsButton = NSButton(frame: NSRect.zero)
                 cell = TestResultCell(nibName: nil, bundle: nil)
             }
             
@@ -119,7 +119,7 @@ class TestResultsControllerSpec: QuickSpec {
                 }
                 
                 it("asserts") {
-                    expect { controller.testResultCell(cell, swapSnapshotsButtonClicked: swapSnapshotsButton) }.to(throwAssertion())
+                    expect { controller.testResultCell(cell, acceptSnapshotsButtonClicked: acceptSnapshotsButton) }.to(throwAssertion())
                 }
             }
             
@@ -130,7 +130,7 @@ class TestResultsControllerSpec: QuickSpec {
                 }
                 
                 it("asserts") {
-                    expect { controller.testResultCell(cell, swapSnapshotsButtonClicked: swapSnapshotsButton) }.to(throwAssertion())
+                    expect { controller.testResultCell(cell, acceptSnapshotsButtonClicked: acceptSnapshotsButton) }.to(throwAssertion())
                 }
             }
             
@@ -138,12 +138,12 @@ class TestResultsControllerSpec: QuickSpec {
                 beforeEach {
                     collectionViewOutlets.testResultsDisplayInfo = displayInfo
                     collectionView.indexPathForItemReturnValue = IndexPath(item: 0, section: 0)
-                    controller.testResultCell(cell, swapSnapshotsButtonClicked: swapSnapshotsButton)
+                    controller.testResultCell(cell, acceptSnapshotsButtonClicked: acceptSnapshotsButton)
                 }
                 
-                it("swaps test result") {
-                    expect(eventHandler.swap___Called).to(beTrue())
-                    expect(eventHandler.swap___ReceivedTestResults).to(equal([testResultDisplayInfo]))
+                it("accepts test result") {
+                    expect(eventHandler.accept___Called).to(beTrue())
+                    expect(eventHandler.accept___ReceivedTestResults).to(equal([testResultDisplayInfo]))
                 }
             }
         }

--- a/FBSnapshotsViewerTests/TestResultsInteractorSpec.swift
+++ b/FBSnapshotsViewerTests/TestResultsInteractorSpec.swift
@@ -37,23 +37,23 @@ class TestResultsInteractor_MockExternalViewer: ExternalViewer {
     }
 }
 
-class TestResultsInteractor_MockSnapshotTestResultSwapper: SnapshotTestResultSwapper {
-    var swapThrows: Bool = false
-    var swapCalled: Bool = false
-    var swapTestResult: SnapshotTestResult?
-    var swappedTestResult: SnapshotTestResult!
-    override func swap(_ testResult: SnapshotTestResult) throws -> SnapshotTestResult {
-        swapCalled = true
-        swapTestResult = testResult
-        if swapThrows {
-            throw SnapshotTestResultSwapperError.canNotBeSwapped(testResult: testResult)
+class TestResultsInteractor_MockSnapshotTestResultAcceptor: SnapshotTestResultAcceptor {
+    var acceptThrows: Bool = false
+    var acceptCalled: Bool = false
+    var acceptTestResult: SnapshotTestResult?
+    var acceptedTestResult: SnapshotTestResult!
+    override func accept(_ testResult: SnapshotTestResult) throws -> SnapshotTestResult {
+        acceptCalled = true
+        acceptTestResult = testResult
+        if acceptThrows {
+            throw SnapshotTestResultAcceptorError.canNotBeAccepted(testResult: testResult)
         }
-        return swappedTestResult
+        return acceptedTestResult
     }
     
-    var canSwapReturnValue: Bool = false
-    override func canSwap(_ testResult: SnapshotTestResult) -> Bool {
-        return canSwapReturnValue
+    var canAcceptReturnValue: Bool = false
+    override func canAccept(_ testResult: SnapshotTestResult) -> Bool {
+        return canAcceptReturnValue
     }
 }
 
@@ -66,7 +66,7 @@ class TestResultsInteractorSpec: QuickSpec {
         var interactor: TestResultsInteractor!
         var pasteboard: PasteboardMock!
         var output: TestResultsInteractorOutputMock!
-        var swapper: TestResultsInteractor_MockSnapshotTestResultSwapper!
+        var acceptor: TestResultsInteractor_MockSnapshotTestResultAcceptor!
         var testResults: [SnapshotTestResult] = []
 
         beforeEach {
@@ -77,14 +77,14 @@ class TestResultsInteractorSpec: QuickSpec {
             testResults = [testResult1, testResult2]
             processLauncher = ProcessLauncher()
             pasteboard = PasteboardMock()
-            swapper = TestResultsInteractor_MockSnapshotTestResultSwapper()
-            swapper.swappedTestResult = SnapshotTestResult.recorded(testInformation: testInformation1, referenceImagePath: "referenceImagePath1", build: build)
+            acceptor = TestResultsInteractor_MockSnapshotTestResultAcceptor()
+            acceptor.acceptedTestResult = SnapshotTestResult.recorded(testInformation: testInformation1, referenceImagePath: "referenceImagePath1", build: build)
             output = TestResultsInteractorOutputMock()
             let builder = TestResultsInteractorBuilder {
                 $0.testResults = testResults
                 $0.externalViewers = ExternalViewers(xcodeViewer: xcodeViewer, kaleidoscopeViewer: kaleidoscopeViewer)
                 $0.processLauncher = processLauncher
-                $0.swapper = swapper
+                $0.acceptor = acceptor
                 $0.pasteboard = pasteboard
             }
             interactor = TestResultsInteractor(builder: builder)
@@ -95,53 +95,53 @@ class TestResultsInteractorSpec: QuickSpec {
             kaleidoscopeViewer.reset()
         }
         
-        describe(".swap") {
+        describe(".accept") {
             var testResult: SnapshotTestResult!
             
             beforeEach {
                 testResult = testResults[0]
             }
             
-            context("when test result can not be swapped") {
+            context("when test result can not be accepted") {
                 beforeEach {
-                    swapper.canSwapReturnValue = false
-                    interactor.swap(testResult: testResult)
+                    acceptor.canAcceptReturnValue = false
+                    interactor.accept(testResult: testResult)
                 }
                 
                 it("does nothing") {
-                    expect(swapper.swapCalled).to(beFalse())
+                    expect(acceptor.acceptCalled).to(beFalse())
                 }
             }
             
-            context("when test result can be swapped") {
+            context("when test result can be accepted") {
                 beforeEach {
-                    swapper.canSwapReturnValue = true
+                    acceptor.canAcceptReturnValue = true
                 }
                 
-                context("when swap throws") {
+                context("when accept throws") {
                     beforeEach {
-                        swapper.swapThrows = true
-                        interactor.swap(testResult: testResult)
+                        acceptor.acceptThrows = true
+                        interactor.accept(testResult: testResult)
                     }
                     
                     it("outputs error") {
-                        expect(output.didFailToSwap_testResult_with_Called).to(beTrue())
+                        expect(output.didFailToAccept_testResult_with_Called).to(beTrue())
                     }
                 }
                 
-                context("when swap doesn't throw") {
+                context("when accept doesn't throw") {
                     beforeEach {
-                        swapper.swapThrows = false
+                        acceptor.acceptThrows = false
                     }
                     
                     context("given presented test result") {
                         beforeEach {
-                            interactor.swap(testResult: testResult)
+                            interactor.accept(testResult: testResult)
                         }
                         
-                        it("swaps") {
-                            expect(swapper.swapCalled).to(beTrue())
-                            expect(output.didFailToSwap_testResult_with_Called).toNot(beTrue())
+                        it("accepts") {
+                            expect(acceptor.acceptCalled).to(beTrue())
+                            expect(output.didFailToAccept_testResult_with_Called).toNot(beTrue())
                         }
                         
                         it("replaces failed test result with recorded") {
@@ -155,11 +155,11 @@ class TestResultsInteractorSpec: QuickSpec {
                         beforeEach {
                             let testInformation = SnapshotTestInformation(testClassName: "Foo", testName: "Bar", testFilePath: "/Baz/Foo.m", testLineNumber: 1)
                             let notPresentedTestResult = SnapshotTestResult.failed(testInformation: testInformation, referenceImagePath: "foo/bar@2x.png", diffImagePath: "foo/bar@2x.png", failedImagePath: "foo/bar@2x.png", build: build)
-                            interactor.swap(testResult: notPresentedTestResult)
+                            interactor.accept(testResult: notPresentedTestResult)
                         }
                         
                         it("outputs error") {
-                            expect(output.didFailToSwap_testResult_with_Called).to(beTrue())
+                            expect(output.didFailToAccept_testResult_with_Called).to(beTrue())
                         }
                     }
                 }

--- a/FBSnapshotsViewerTests/TestResultsPresenterSpec.swift
+++ b/FBSnapshotsViewerTests/TestResultsPresenterSpec.swift
@@ -21,10 +21,10 @@ class TestResultsPresenter_MockTestResultsDisplayInfosCollector: TestResultsDisp
 }
 
 class TestResultsPresenter_MockTestResultsInteractorInputMock: TestResultsInteractorInputMock {
-    var swapCalledCounter: Int = 0
-    override func swap(testResult: SnapshotTestResult) {
-        super.swap(testResult: testResult)
-        swapCalledCounter += 1
+    var acceptCalledCounter: Int = 0
+    override func accept(testResult: SnapshotTestResult) {
+        super.accept(testResult: testResult)
+        acceptCalledCounter += 1
     }
 }
 
@@ -44,7 +44,7 @@ class TestResultsPresenterSpec: QuickSpec {
             presenter.userInterface = userInterface
         }
         
-        describe(".swap") {
+        describe(".accept") {
             var testResults: [TestResultDisplayInfo] = []
             
             beforeEach {
@@ -57,11 +57,11 @@ class TestResultsPresenterSpec: QuickSpec {
                 let testResultDisplayInfo2 = TestResultDisplayInfo(testResult: testResult2)
                 testResults = [testResultDisplayInfo1, testResultDisplayInfo2]
                 interactor.testResults = [testResult1, testResult2]
-                presenter.swap(testResults)
+                presenter.accept(testResults)
             }
             
-            it("swaps all given test results") {
-                expect(interactor.swapCalledCounter).to(equal(2))
+            it("accepts all given test results") {
+                expect(interactor.acceptCalledCounter).to(equal(2))
             }
             
             it("updates user interface") {

--- a/FBSnapshotsViewerTests/TestResultsSectionDisplayInfoSpec.swift
+++ b/FBSnapshotsViewerTests/TestResultsSectionDisplayInfoSpec.swift
@@ -34,7 +34,7 @@ class TestResultsSectionDisplayInfoSpec: QuickSpec {
             }
         }
         
-        describe(".hasItemsToSwap") {
+        describe(".hasItemsToAccept") {
             var build: Build!
             var items: [TestResultDisplayInfo] = []
             var title: TestResultsSectionTitleDisplayInfo!
@@ -46,7 +46,7 @@ class TestResultsSectionDisplayInfoSpec: QuickSpec {
                 title = TestResultsSectionTitleDisplayInfo(build: build, testContext: "TestContext")
             }
             
-            context("when there is display info that can be swapped") {
+            context("when there is display info that can be accepted") {
                 beforeEach {
                     let testResult1 = SnapshotTestResult.recorded(testInformation: testInformation, referenceImagePath: "foo1/foo1.png", build: build)
                     let testResult2 = SnapshotTestResult.failed(testInformation: testInformation, referenceImagePath: "foo/bar.png", diffImagePath: "foo/foo.png", failedImagePath: "bar/bar.png", build: build)
@@ -58,11 +58,11 @@ class TestResultsSectionDisplayInfoSpec: QuickSpec {
                 }
                 
                 it("returns true") {
-                    expect(displayInfo.hasItemsToSwap).to(beTrue())
+                    expect(displayInfo.hasItemsToAccept).to(beTrue())
                 }
             }
             
-            context("when there is no display info that can be swapped") {
+            context("when there is no display info that can be accepted") {
                 beforeEach {
                     let testResult1 = SnapshotTestResult.recorded(testInformation: testInformation, referenceImagePath: "foo1/foo1.png", build: build)
                     let testResult2 = SnapshotTestResult.recorded(testInformation: testInformation, referenceImagePath: "foo1/foo2.png", build: build)
@@ -74,7 +74,7 @@ class TestResultsSectionDisplayInfoSpec: QuickSpec {
                 }
                 
                 it("returns false") {
-                    expect(displayInfo.hasItemsToSwap).to(beFalse())
+                    expect(displayInfo.hasItemsToAccept).to(beFalse())
                 }
             }
         }

--- a/Vendor/Sourcery/CodeGenerated/AutoMockable.generated.swift
+++ b/Vendor/Sourcery/CodeGenerated/AutoMockable.generated.swift
@@ -440,13 +440,13 @@ class TestResultCellDelegateMock: TestResultCellDelegate {
     }
     //MARK: - testResultCell
 
-    var testResultCell___swapSnapshotsButtonClicked_Called = false
-    var testResultCell___swapSnapshotsButtonClicked_ReceivedArguments: (cell: TestResultCell, swapSnapshotsButtonClicked: NSButton)?
+    var testResultCell___acceptSnapshotsButtonClicked_Called = false
+    var testResultCell___acceptSnapshotsButtonClicked_ReceivedArguments: (cell: TestResultCell, acceptSnapshotsButtonClicked: NSButton)?
 
-    func testResultCell(_ cell: TestResultCell, swapSnapshotsButtonClicked: NSButton) {
+    func testResultCell(_ cell: TestResultCell, acceptSnapshotsButtonClicked: NSButton) {
 
-        testResultCell___swapSnapshotsButtonClicked_Called = true
-        testResultCell___swapSnapshotsButtonClicked_ReceivedArguments = (cell: cell, swapSnapshotsButtonClicked: swapSnapshotsButtonClicked)
+        testResultCell___acceptSnapshotsButtonClicked_Called = true
+        testResultCell___acceptSnapshotsButtonClicked_ReceivedArguments = (cell: cell, acceptSnapshotsButtonClicked: acceptSnapshotsButtonClicked)
     }
     //MARK: - testResultCell
 
@@ -464,13 +464,13 @@ class TestResultsHeaderDelegateMock: TestResultsHeaderDelegate {
 
     //MARK: - testResultsHeader
 
-    var testResultsHeader___swapSnapshotsButtonClicked_Called = false
-    var testResultsHeader___swapSnapshotsButtonClicked_ReceivedArguments: (header: TestResultsHeader, swapSnapshotsButtonClicked: NSButton)?
+    var testResultsHeader___acceptSnapshotsButtonClicked_Called = false
+    var testResultsHeader___acceptSnapshotsButtonClicked_ReceivedArguments: (header: TestResultsHeader, acceptSnapshotsButtonClicked: NSButton)?
 
-    func testResultsHeader(_ header: TestResultsHeader, swapSnapshotsButtonClicked: NSButton) {
+    func testResultsHeader(_ header: TestResultsHeader, acceptSnapshotsButtonClicked: NSButton) {
 
-        testResultsHeader___swapSnapshotsButtonClicked_Called = true
-        testResultsHeader___swapSnapshotsButtonClicked_ReceivedArguments = (header: header, swapSnapshotsButtonClicked: swapSnapshotsButtonClicked)
+        testResultsHeader___acceptSnapshotsButtonClicked_Called = true
+        testResultsHeader___acceptSnapshotsButtonClicked_ReceivedArguments = (header: header, acceptSnapshotsButtonClicked: acceptSnapshotsButtonClicked)
     }
 }
 class TestResultsInteractorInputMock: TestResultsInteractorInput {
@@ -497,15 +497,15 @@ class TestResultsInteractorInputMock: TestResultsInteractorInput {
         openInXcode_testResult_Called = true
         openInXcode_testResult_ReceivedTestResult = testResult
     }
-    //MARK: - swap
+    //MARK: - accept
 
-    var swap_testResult_Called = false
-    var swap_testResult_ReceivedTestResult: SnapshotTestResult?
+    var accept_testResult_Called = false
+    var accept_testResult_ReceivedTestResult: SnapshotTestResult?
 
-    func swap(testResult: SnapshotTestResult) {
+    func accept(testResult: SnapshotTestResult) {
 
-        swap_testResult_Called = true
-        swap_testResult_ReceivedTestResult = testResult
+        accept_testResult_Called = true
+        accept_testResult_ReceivedTestResult = testResult
     }
     //MARK: - copy
 
@@ -521,15 +521,15 @@ class TestResultsInteractorInputMock: TestResultsInteractorInput {
 class TestResultsInteractorOutputMock: TestResultsInteractorOutput {
 
 
-    //MARK: - didFailToSwap
+    //MARK: - didFailToAccept
 
-    var didFailToSwap_testResult_with_Called = false
-    var didFailToSwap_testResult_with_ReceivedArguments: (testResult: SnapshotTestResult, error: Error)?
+    var didFailToAccept_testResult_with_Called = false
+    var didFailToAccept_testResult_with_ReceivedArguments: (testResult: SnapshotTestResult, error: Error)?
 
-    func didFailToSwap(testResult: SnapshotTestResult, with error: Error) {
+    func didFailToAccept(testResult: SnapshotTestResult, with error: Error) {
 
-        didFailToSwap_testResult_with_Called = true
-        didFailToSwap_testResult_with_ReceivedArguments = (testResult: testResult, error: error)
+        didFailToAccept_testResult_with_Called = true
+        didFailToAccept_testResult_with_ReceivedArguments = (testResult: testResult, error: error)
     }
 }
 class TestResultsModuleInterfaceMock: TestResultsModuleInterface {
@@ -573,15 +573,15 @@ class TestResultsModuleInterfaceMock: TestResultsModuleInterface {
         selectDiffMode___Called = true
         selectDiffMode___ReceivedDiffMode = diffMode
     }
-    //MARK: - swap
+    //MARK: - accept
 
-    var swap___Called = false
-    var swap___ReceivedTestResults: [TestResultDisplayInfo]?
+    var accept___Called = false
+    var accept___ReceivedTestResults: [TestResultDisplayInfo]?
 
-    func swap(_ testResults: [TestResultDisplayInfo]) {
+    func accept(_ testResults: [TestResultDisplayInfo]) {
 
-        swap___Called = true
-        swap___ReceivedTestResults = testResults
+        accept___Called = true
+        accept___ReceivedTestResults = testResults
     }
     //MARK: - copy
 


### PR DESCRIPTION
Replaced "Swap" with "Accept" and "Accept All" in interface and throughout variable and function naming in code. As discussed in: https://github.com/Antondomashnev/FBSnapshotsViewer/issues/27