### PR TITLE
Remove accepted images from failed image path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.8.1 (Next)
 
 * Your contribution here.
+* [#70](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/70): Remove accepted images from failed image path. - [@babbage](https://github.com/babbage).
 
 ### 0.8.0 (11.10.2017)
 

--- a/FBSnapshotsViewer/Extensions/FileManager+Move.swift
+++ b/FBSnapshotsViewer/Extensions/FileManager+Move.swift
@@ -13,4 +13,8 @@ extension FileManager {
         try self.removeItem(at: toURL)
         try self.copyItem(at: fromURL, to: toURL)
     }
+
+    func deleteItem(at url: URL) throws {
+        try self.removeItem(at: url)
+    }
 }


### PR DESCRIPTION
When a new image is accepted, remove the reference image, failed image, and diff image from the failed image path.