### PR TITLE
Mechanism to reject snapshot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Your contribution here.
 * [#69](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/69): Replace Swap with Accept and Accept All. - [@babbage](https://github.com/babbage).
+* [#71](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/71): Mechanism to reject snapshot. - [@babbage](https://github.com/babbage).
 
 ### 0.8.0 (11.10.2017)
 

--- a/FBSnapshotsViewer/Extensions/FileManager+Move.swift
+++ b/FBSnapshotsViewer/Extensions/FileManager+Move.swift
@@ -10,7 +10,13 @@ import Foundation
 
 extension FileManager {
     func moveItem(at fromURL: URL, to toURL: URL) throws {
-        try self.removeItem(at: toURL)
+        try deleteIfExists(at: toURL)
         try self.copyItem(at: fromURL, to: toURL)
+    }
+
+    func deleteIfExists(at url: URL) throws {
+        if fileExists(atPath: url.path) {
+            try self.removeItem(at: url)
+        }
     }
 }

--- a/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
+++ b/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
@@ -69,8 +69,8 @@ class SnapshotTestResultAcceptor {
     }
 
     func reject(_ testResult: SnapshotTestResult) throws -> SnapshotTestResult {
-        guard case let SnapshotTestResult.failed(testInformation, referenceImagePath, _, _, build) = testResult, canSwap(testResult) else {
-            throw SnapshotTestResultSwapperError.canNotBeRejected(testResult: testResult)
+        guard case let SnapshotTestResult.failed(testInformation, referenceImagePath, _, _, build) = testResult, canAccept(testResult) else {
+            throw SnapshotTestResultAcceptorError.canNotBeRejected(testResult: testResult)
         }
         do {
             try removeTestImages(testResult)
@@ -78,13 +78,13 @@ class SnapshotTestResultAcceptor {
             return SnapshotTestResult.rejected(testInformation: testInformation, referenceImagePath: referenceImagePath, build: build)
         }
         catch let error {
-            throw SnapshotTestResultSwapperError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)
+            throw SnapshotTestResultAcceptorError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)
         }
     }
 
     func removeTestImages(_ testResult: SnapshotTestResult) throws {
         guard case let SnapshotTestResult.failed(_, referenceImagePath, diffImagePath, failedImagePath, _) = testResult else {
-            throw SnapshotTestResultSwapperError.canNotBeSwapped(testResult: testResult)
+            throw SnapshotTestResultAcceptorError.canNotBeAccepted(testResult: testResult)
         }
         
         let referenceImageURL = URL(fileURLWithPath: referenceImagePath, isDirectory: false)
@@ -92,12 +92,12 @@ class SnapshotTestResultAcceptor {
         let failedImageURL = URL(fileURLWithPath: failedImagePath, isDirectory: false)
         
         do {
-            try fileManager.deleteItem(at: referenceImageURL)
-            try fileManager.deleteItem(at: diffImageURL)
-            try fileManager.deleteItem(at: failedImageURL)
+            try fileManager.deleteIfExists(at: referenceImageURL)
+            try fileManager.deleteIfExists(at: diffImageURL)
+            try fileManager.deleteIfExists(at: failedImageURL)
         }
         catch let error {
-            throw SnapshotTestResultSwapperError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)
+            throw SnapshotTestResultAcceptorError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)
         }
     }
 }

--- a/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
+++ b/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
@@ -66,4 +66,23 @@ class SnapshotTestResultAcceptor {
             throw SnapshotTestResultAcceptorError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)
         }
     }
+
+    func removeTestImages(_ testResult: SnapshotTestResult) throws {
+        guard case let SnapshotTestResult.failed(_, referenceImagePath, diffImagePath, failedImagePath, _) = testResult else {
+            throw SnapshotTestResultSwapperError.canNotBeSwapped(testResult: testResult)
+        }
+        
+        let referenceImageURL = URL(fileURLWithPath: referenceImagePath, isDirectory: false)
+        let diffImageURL = URL(fileURLWithPath: diffImagePath, isDirectory: false)
+        let failedImageURL = URL(fileURLWithPath: failedImagePath, isDirectory: false)
+        
+        do {
+            try fileManager.removeItem(at: referenceImageURL)
+            try fileManager.removeItem(at: diffImageURL)
+            try fileManager.removeItem(at: failedImageURL)
+        }
+        catch let error {
+            throw SnapshotTestResultSwapperError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)
+        }
+    }
 }

--- a/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
+++ b/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
@@ -92,9 +92,9 @@ class SnapshotTestResultAcceptor {
         let failedImageURL = URL(fileURLWithPath: failedImagePath, isDirectory: false)
         
         do {
-            try fileManager.removeItem(at: referenceImageURL)
-            try fileManager.removeItem(at: diffImageURL)
-            try fileManager.removeItem(at: failedImageURL)
+            try fileManager.deleteItem(at: referenceImageURL)
+            try fileManager.deleteItem(at: diffImageURL)
+            try fileManager.deleteItem(at: failedImageURL)
         }
         catch let error {
             throw SnapshotTestResultSwapperError.canNotPerformFileManagerOperation(testResult: testResult, underlyingError: error)

--- a/FBSnapshotsViewer/Models/SnapshotTestResult.swift
+++ b/FBSnapshotsViewer/Models/SnapshotTestResult.swift
@@ -36,6 +36,8 @@ enum SnapshotTestResult: AutoEquatable {
         switch self {
         case let .recorded(testInformation, _, _):
             return testInformation
+        case let .rejected(testInformation, _, _):
+            return testInformation
         case let .failed(testInformation, _, _, _, _):
             return testInformation
         }
@@ -45,6 +47,8 @@ enum SnapshotTestResult: AutoEquatable {
         switch self {
         case let .recorded(_, _, build):
             return build
+        case let .rejected(_, _, build):
+                return build
         case let .failed(_, _, _, _, build):
             return build
         }
@@ -54,6 +58,10 @@ enum SnapshotTestResult: AutoEquatable {
                   referenceImagePath: String,
                   build: Build)
 
+    case rejected(testInformation: SnapshotTestInformation,
+        referenceImagePath: String,
+        build: Build)
+    
     case failed(testInformation: SnapshotTestInformation,
                 referenceImagePath: String,
                 diffImagePath: String,

--- a/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractor.swift
+++ b/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractor.swift
@@ -88,12 +88,26 @@ extension TestResultsInteractor: TestResultsInteractorInput {
         }
     }
     
+    func reject(testResult: SnapshotTestResult) {
+        if !swapper.canSwap(testResult) {
+            return
+        }
+        do {
+            _ = try swapper.reject(testResult)
+        }
+        catch let error {
+            output?.didFailToReject(testResult: testResult, with: error)
+        }
+    }
+    
     func copy(testResult: SnapshotTestResult) {
         var url: URL
         switch testResult {
         case let .failed(_, _, _, failedImagePath, _):
             url = URL(fileURLWithPath: failedImagePath)
         case let .recorded(_, referenceImagePath, _):
+            url = URL(fileURLWithPath: referenceImagePath)
+        case let .rejected(_, referenceImagePath, _):
             url = URL(fileURLWithPath: referenceImagePath)
         }
         pasteboard.copyImage(at: url)

--- a/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractor.swift
+++ b/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractor.swift
@@ -89,11 +89,11 @@ extension TestResultsInteractor: TestResultsInteractorInput {
     }
     
     func reject(testResult: SnapshotTestResult) {
-        if !swapper.canSwap(testResult) {
+        if !acceptor.canAccept(testResult) {
             return
         }
         do {
-            _ = try swapper.reject(testResult)
+            _ = try acceptor.reject(testResult)
         }
         catch let error {
             output?.didFailToReject(testResult: testResult, with: error)

--- a/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractorIO.swift
+++ b/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractorIO.swift
@@ -13,9 +13,11 @@ protocol TestResultsInteractorInput: class, AutoMockable {
     func openInKaleidoscope(testResult: SnapshotTestResult)
     func openInXcode(testResult: SnapshotTestResult)
     func accept(testResult: SnapshotTestResult)
+    func reject(testResult: SnapshotTestResult)
     func copy(testResult: SnapshotTestResult)
 }
 
 protocol TestResultsInteractorOutput: class, AutoMockable {
     func didFailToAccept(testResult: SnapshotTestResult, with error: Error)
+    func didFailToReject(testResult: SnapshotTestResult, with error: Error)
 }

--- a/FBSnapshotsViewer/Test Results/Presenter/TestResultDisplayInfo.swift
+++ b/FBSnapshotsViewer/Test Results/Presenter/TestResultDisplayInfo.swift
@@ -80,6 +80,10 @@ struct TestResultDisplayInfo: AutoEquatable {
             self.referenceImageURL = URL(fileURLWithPath: referenceImagePath)
             self.diffImageURL = nil
             self.failedImageURL = nil
+        case let .rejected(_, referenceImagePath, _):
+            self.referenceImageURL = URL(fileURLWithPath: referenceImagePath)
+            self.diffImageURL = nil
+            self.failedImageURL = nil
         case let .failed(_, referenceImagePath, diffImagePath, failedImagePath, _):
             self.referenceImageURL = URL(fileURLWithPath: referenceImagePath)
             self.diffImageURL = URL(fileURLWithPath: diffImagePath)

--- a/FBSnapshotsViewer/Test Results/Presenter/TestResultsPresenter.swift
+++ b/FBSnapshotsViewer/Test Results/Presenter/TestResultsPresenter.swift
@@ -49,6 +49,13 @@ extension TestResultsPresenter: TestResultsModuleInterface {
         updateUserInterface()
     }
     
+    func reject(_ testResults: [TestResultDisplayInfo]) {
+        for testResultInfo in testResults {
+            interactor?.reject(testResult: testResultInfo.testResult)
+        }
+        updateUserInterface()
+    }
+    
     func copy(testResultDisplayInfo: TestResultDisplayInfo) {
         interactor?.copy(testResult: testResultDisplayInfo.testResult)
     }
@@ -61,5 +68,13 @@ extension TestResultsPresenter: TestResultsInteractorOutput {
         failToAcceptAlert.alertStyle = .critical
         failToAcceptAlert.messageText = "Ops, accept can not be done. \(error.localizedDescription). Please report an issue https://github.com/Antondomashnev/FBSnapshotsViewer/issues/new"
         failToAcceptAlert.runModal()
+    }
+
+    func didFailToReject(testResult: SnapshotTestResult, with error: Error) {
+        let failToRejectAlert = NSAlert()
+        failToRejectAlert.addButton(withTitle: "Ok")
+        failToRejectAlert.alertStyle = .critical
+        failToRejectAlert.messageText = "Oops, rejection cannot be completed. \(error.localizedDescription). Please report an issue https://github.com/Antondomashnev/FBSnapshotsViewer/issues/new"
+        failToRejectAlert.runModal()
     }
 }

--- a/FBSnapshotsViewer/Test Results/TestResultsModuleInterface.swift
+++ b/FBSnapshotsViewer/Test Results/TestResultsModuleInterface.swift
@@ -14,5 +14,6 @@ protocol TestResultsModuleInterface: class, AutoMockable {
     func openInXcode(testResultDisplayInfo: TestResultDisplayInfo)
     func selectDiffMode(_ diffMode: TestResultsDiffMode)
     func accept(_ testResults: [TestResultDisplayInfo])
+    func reject(_ testResults: [TestResultDisplayInfo])
     func copy(testResultDisplayInfo: TestResultDisplayInfo)
 }

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultCell.swift
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultCell.swift
@@ -13,6 +13,7 @@ protocol TestResultCellDelegate: class, AutoMockable {
     func testResultCell(_ cell: TestResultCell, viewInXcodeButtonClicked: NSButton)
     func testResultCell(_ cell: TestResultCell, viewInKaleidoscopeButtonClicked: NSButton)
     func testResultCell(_ cell: TestResultCell, acceptSnapshotsButtonClicked: NSButton)
+    func testResultCell(_ cell: TestResultCell, rejectSnapshotButtonClicked: NSButton)
     func testResultCell(_ cell: TestResultCell, copySnapshotButtonClicked: NSButton)
 }
 
@@ -25,6 +26,7 @@ class TestResultCell: NSCollectionViewItem {
     @IBOutlet private weak var viewInKaleidoscopeButton: NSButton!
     @IBOutlet private weak var viewInXcodeButton: NSButton!
     @IBOutlet private weak var acceptSnapshotsButton: NSButton!
+    @IBOutlet private weak var rejectSnapshotsButton: NSButton!
     @IBOutlet private weak var copySnapshotButton: NSButton!
     
     @IBOutlet private weak var imagesContainerView: NSView!
@@ -139,5 +141,9 @@ class TestResultCell: NSCollectionViewItem {
     
     @objc @IBAction func acceptSnapshotsButtonClicked(_ sender: NSButton) {
         delegate?.testResultCell(self, acceptSnapshotsButtonClicked: sender)
+    }
+
+    @objc @IBAction func rejectSnapshotButtonClicked(_ sender: NSButton) {
+        delegate?.testResultCell(self, rejectSnapshotButtonClicked: sender)
     }
 }

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultCell.xib
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -190,16 +190,6 @@
                                 <action selector="viewInXcodeButtonClicked:" target="i7H-GG-lM3" id="Cng-5d-SBQ"/>
                             </connections>
                         </button>
-                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dTc-pr-6Mk">
-                            <rect key="frame" x="200" y="0.0" width="52" height="17"/>
-                            <buttonCell key="cell" type="inline" title="Accept" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="erZ-Db-LCI">
-                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="smallSystemBold"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="acceptSnapshotsButtonClicked:" target="i7H-GG-lM3" id="9Sg-cx-JnE"/>
-                            </connections>
-                        </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="T5h-WQ-msk">
                             <rect key="frame" x="104" y="-1" width="88" height="17"/>
                             <buttonCell key="cell" type="inline" title="Kaleidoscope" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="vfP-WI-LhL">
@@ -210,16 +200,38 @@
                                 <action selector="viewInKaleidoscopeButtonClicked:" target="i7H-GG-lM3" id="39C-6q-BzH"/>
                             </connections>
                         </button>
+                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1Uk-XP-BAf" userLabel="Reject Snapshot Button">
+                            <rect key="frame" x="200" y="0.0" width="48" height="17"/>
+                            <buttonCell key="cell" type="inline" title="Reject" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="NLl-oz-N9O">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="smallSystemBold"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="rejectSnapshotButtonClicked:" target="i7H-GG-lM3" id="EO3-UA-DWT"/>
+                            </connections>
+                        </button>
+                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dTc-pr-6Mk" userLabel="Accept Snapshots Button">
+                            <rect key="frame" x="256" y="0.0" width="52" height="17"/>
+                            <buttonCell key="cell" type="inline" title="Accept" bezelStyle="inline" alignment="center" borderStyle="border" inset="2" id="erZ-Db-LCI">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="smallSystemBold"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="acceptSnapshotsButtonClicked:" target="i7H-GG-lM3" id="Yab-UN-Gdr"/>
+                            </connections>
+                        </button>
                     </subviews>
                     <constraints>
                         <constraint firstItem="dTc-pr-6Mk" firstAttribute="centerY" secondItem="AHf-ta-nvJ" secondAttribute="centerY" id="1J2-q4-hjM"/>
-                        <constraint firstItem="dTc-pr-6Mk" firstAttribute="leading" secondItem="T5h-WQ-msk" secondAttribute="trailing" constant="8" id="2UL-3w-aAn"/>
                         <constraint firstItem="T5h-WQ-msk" firstAttribute="leading" secondItem="82c-wB-1dx" secondAttribute="trailing" constant="8" id="ENj-Hb-uwX"/>
                         <constraint firstItem="ywy-Aa-jQX" firstAttribute="centerY" secondItem="AHf-ta-nvJ" secondAttribute="centerY" id="Nuh-b9-YOz"/>
+                        <constraint firstItem="1Uk-XP-BAf" firstAttribute="trailing" secondItem="dTc-pr-6Mk" secondAttribute="leading" constant="-8" id="Pte-bc-IGC"/>
                         <constraint firstAttribute="height" constant="17" id="S1P-8B-JMQ"/>
                         <constraint firstItem="T5h-WQ-msk" firstAttribute="centerY" secondItem="AHf-ta-nvJ" secondAttribute="centerY" id="a3W-2X-DLg"/>
                         <constraint firstItem="82c-wB-1dx" firstAttribute="centerY" secondItem="AHf-ta-nvJ" secondAttribute="centerY" id="akK-SP-WOg"/>
                         <constraint firstItem="ywy-Aa-jQX" firstAttribute="leading" secondItem="AHf-ta-nvJ" secondAttribute="leading" id="ckn-RE-UP1"/>
+                        <constraint firstItem="1Uk-XP-BAf" firstAttribute="leading" secondItem="T5h-WQ-msk" secondAttribute="trailing" constant="8" id="iiq-Wf-19r"/>
+                        <constraint firstItem="1Uk-XP-BAf" firstAttribute="centerY" secondItem="AHf-ta-nvJ" secondAttribute="centerY" id="shi-Gf-IYK"/>
                         <constraint firstItem="82c-wB-1dx" firstAttribute="leading" secondItem="ywy-Aa-jQX" secondAttribute="trailing" constant="8" id="vHK-dX-xDw"/>
                     </constraints>
                 </customView>
@@ -248,7 +260,7 @@
         </customView>
         <collectionViewItem nibName="TestResultCell" id="i7H-GG-lM3" customClass="TestResultCell" customModule="FBSnapshotsViewer" customModuleProvider="target">
             <connections>
-                <outlet property="acceptSnapshotsButton" destination="dTc-pr-6Mk" id="XcZ-34-QUG"/>
+                <outlet property="acceptSnapshotsButton" destination="dTc-pr-6Mk" id="0aI-xK-dlm"/>
                 <outlet property="actionsContainerView" destination="AHf-ta-nvJ" id="ggA-yn-13p"/>
                 <outlet property="copySnapshotButton" destination="ywy-Aa-jQX" id="Uwx-dp-kHu"/>
                 <outlet property="diffContainerView" destination="HvH-e1-A4r" id="Ydb-cW-xPt"/>
@@ -258,6 +270,7 @@
                 <outlet property="imagesContainerView" destination="LJB-1E-GeF" id="15u-q3-AcU"/>
                 <outlet property="referenceImageTitleLabel" destination="H6x-U9-K6u" id="wXt-ua-Ggv"/>
                 <outlet property="referenceImageView" destination="K85-1M-wcy" id="UtW-Gp-pOZ"/>
+                <outlet property="rejectSnapshotsButton" destination="1Uk-XP-BAf" id="Hwh-mu-Ulm"/>
                 <outlet property="separatorView" destination="Xdr-DA-S5B" id="axP-xd-ghd"/>
                 <outlet property="splitContainerView" destination="oaS-Kh-fqd" id="ID4-fk-Axc"/>
                 <outlet property="testInfoContainerView" destination="YEn-VX-jtO" id="RRJ-ht-Nth"/>

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultsController.swift
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultsController.swift
@@ -75,6 +75,15 @@ extension TestResultsController: TestResultCellDelegate {
         collectionView.reloadSections(IndexSet(integer: testResultInfo.indexPath.section))
     }
     
+    func testResultCell(_ cell: TestResultCell, rejectSnapshotButtonClicked: NSButton) {
+        guard let testResultInfo = findTestResultInfo(for: cell) else {
+            assertionFailure("Unexpected TestResultCellDelegate callback about reject snapshot button click")
+            return
+        }
+        eventHandler.reject([testResultInfo.info])
+        collectionView.reloadSections(IndexSet(integer: testResultInfo.indexPath.section))
+    }
+    
     func testResultCell(_ cell: TestResultCell, viewInXcodeButtonClicked: NSButton) {
         openIn(eventHandler.openInXcode, from: cell)
     }

--- a/Vendor/Sourcery/CodeGenerated/AutoEquatable.generated.swift
+++ b/Vendor/Sourcery/CodeGenerated/AutoEquatable.generated.swift
@@ -165,6 +165,11 @@ internal func == (lhs: SnapshotTestResult, rhs: SnapshotTestResult) -> Bool {
         if lhs.referenceImagePath != rhs.referenceImagePath { return false }
         if lhs.build != rhs.build { return false }
         return true
+    case (.rejected(let lhs), .rejected(let rhs)): 
+        if lhs.testInformation != rhs.testInformation { return false }
+        if lhs.referenceImagePath != rhs.referenceImagePath { return false }
+        if lhs.build != rhs.build { return false }
+        return true
     case (.failed(let lhs), .failed(let rhs)): 
         if lhs.testInformation != rhs.testInformation { return false }
         if lhs.referenceImagePath != rhs.referenceImagePath { return false }

--- a/Vendor/Sourcery/CodeGenerated/AutoMockable.generated.swift
+++ b/Vendor/Sourcery/CodeGenerated/AutoMockable.generated.swift
@@ -450,6 +450,16 @@ class TestResultCellDelegateMock: TestResultCellDelegate {
     }
     //MARK: - testResultCell
 
+    var testResultCell___rejectSnapshotButtonClicked_Called = false
+    var testResultCell___rejectSnapshotButtonClicked_ReceivedArguments: (cell: TestResultCell, rejectSnapshotButtonClicked: NSButton)?
+
+    func testResultCell(_ cell: TestResultCell, rejectSnapshotButtonClicked: NSButton) {
+
+        testResultCell___rejectSnapshotButtonClicked_Called = true
+        testResultCell___rejectSnapshotButtonClicked_ReceivedArguments = (cell: cell, rejectSnapshotButtonClicked: rejectSnapshotButtonClicked)
+    }
+    //MARK: - testResultCell
+
     var testResultCell___copySnapshotButtonClicked_Called = false
     var testResultCell___copySnapshotButtonClicked_ReceivedArguments: (cell: TestResultCell, copySnapshotButtonClicked: NSButton)?
 
@@ -507,6 +517,16 @@ class TestResultsInteractorInputMock: TestResultsInteractorInput {
         accept_testResult_Called = true
         accept_testResult_ReceivedTestResult = testResult
     }
+    //MARK: - reject
+
+    var reject_testResult_Called = false
+    var reject_testResult_ReceivedTestResult: SnapshotTestResult?
+
+    func reject(testResult: SnapshotTestResult) {
+
+        reject_testResult_Called = true
+        reject_testResult_ReceivedTestResult = testResult
+    }
     //MARK: - copy
 
     var copy_testResult_Called = false
@@ -530,6 +550,16 @@ class TestResultsInteractorOutputMock: TestResultsInteractorOutput {
 
         didFailToAccept_testResult_with_Called = true
         didFailToAccept_testResult_with_ReceivedArguments = (testResult: testResult, error: error)
+    }
+    //MARK: - didFailToReject
+
+    var didFailToReject_testResult_with_Called = false
+    var didFailToReject_testResult_with_ReceivedArguments: (testResult: SnapshotTestResult, error: Error)?
+
+    func didFailToReject(testResult: SnapshotTestResult, with error: Error) {
+
+        didFailToReject_testResult_with_Called = true
+        didFailToReject_testResult_with_ReceivedArguments = (testResult: testResult, error: error)
     }
 }
 class TestResultsModuleInterfaceMock: TestResultsModuleInterface {
@@ -582,6 +612,16 @@ class TestResultsModuleInterfaceMock: TestResultsModuleInterface {
 
         accept___Called = true
         accept___ReceivedTestResults = testResults
+    }
+    //MARK: - reject
+
+    var reject___Called = false
+    var reject___ReceivedTestResults: [TestResultDisplayInfo]?
+
+    func reject(_ testResults: [TestResultDisplayInfo]) {
+
+        reject___Called = true
+        reject___ReceivedTestResults = testResults
     }
     //MARK: - copy
 


### PR DESCRIPTION
Where a snapshot displays a regression, provides an option to reject a snapshot. This removes the snapshot test files from the test results directory, and removes it from the snapshot results. The original reference file remains.

In order to implement this new function, this pull request implements the same removeTestImages supporter function that is incorporated in the RemoveAccepted pull request. The two pull requests are not however dependent on each other.