### PR TITLE
Recognise and enable acceptance of AutoRecorded images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Your contribution here.
 * [#69](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/69): Replace Swap with Accept and Accept All. - [@babbage](https://github.com/babbage).
+* [#72](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/72): Recognise and enable acceptance of AutoRecorded images. - [@babbage](https://github.com/babbage).
 
 ### 0.8.0 (11.10.2017)
 

--- a/FBSnapshotsViewer/Extensions/FileManager+Move.swift
+++ b/FBSnapshotsViewer/Extensions/FileManager+Move.swift
@@ -13,10 +13,10 @@ extension FileManager {
         try deleteIfExists(at: toURL)
         try self.copyItem(at: fromURL, to: toURL)
     }
-}
 
-func deleteIfExists(at url: URL) throws {
-    if fileExists(atPath: url.path) {
-        try self.removeItem(at: url)
+    func deleteIfExists(at url: URL) throws {
+        if fileExists(atPath: url.path) {
+            try self.removeItem(at: url)
+        }
     }
 }

--- a/FBSnapshotsViewer/Extensions/FileManager+Move.swift
+++ b/FBSnapshotsViewer/Extensions/FileManager+Move.swift
@@ -10,7 +10,13 @@ import Foundation
 
 extension FileManager {
     func moveItem(at fromURL: URL, to toURL: URL) throws {
-        try self.removeItem(at: toURL)
+        try deleteIfExists(at: toURL)
         try self.copyItem(at: fromURL, to: toURL)
+    }
+}
+
+func deleteIfExists(at url: URL) throws {
+    if fileExists(atPath: url.path) {
+        try self.removeItem(at: url)
     }
 }

--- a/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
+++ b/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
@@ -34,7 +34,7 @@ class SnapshotTestResultAcceptor {
         let failedImageSizeSuffix = imagePath.substring(with: failedImageSizeSuffixRange)
         let recordedImageURLs = testResult.build.fbReferenceImageDirectoryURLs.flatMap { fbReferenceImageDirectoryURL -> URL? in
             let url = fbReferenceImageDirectoryURL.appendingPathComponent(testResult.testClassName).appendingPathComponent("\(testResult.testName)\(failedImageSizeSuffix)").appendingPathExtension("png")
-            return fileManager.fileExists(atPath: url.path) ? url : nil
+            return url
         }
         guard let url = recordedImageURLs.first else {
             throw SnapshotTestResultAcceptorError.notExistedRecordedImage(testResult: testResult)

--- a/FBSnapshotsViewer/Models/ApplicationLogLine.swift
+++ b/FBSnapshotsViewer/Models/ApplicationLogLine.swift
@@ -34,6 +34,7 @@ struct ApplicationLogLineIndicatorContainer {
     static func snapshotTestErrorMessageIndicators(for configuration: Configuration) -> [String] {
         return [" : ((noErrors) is true) failed - Snapshot comparison failed",
                 " : failed - Snapshot comparison failed: Optional(Error Domain=FBSnapshotTestControllerErrorDomain Code=4",
+                " : failed - No previous reference image. New image has been stored for approval.",
                 " : failed - Test ran in record mode."]
     }
 }


### PR DESCRIPTION
Complementary feature to the implementation of AutoRecord proposed to iOSSnapshotTestCase in this pull request: https://github.com/uber/ios-snapshot-test-case/pull/32. Enables image to be accepted (“swapped”) as a reference image, when an original reference image does not exist.