### PR TITLE
Migrate to Swift 4.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#70](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/70): Remove accepted images from failed image path. - [@babbage](https://github.com/babbage).
 * [#76](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/76): Update for Xcode 10 .xcresult file format. - [@babbage](https://github.com/babbage).
 * [#78](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/78): Resolve Xcode warnings. Update dependencies. - [@babbage](https://github.com/babbage).
+* [#79](https://github.com/Antondomashnev/FBSnapshotsViewer/pull/79): Migrate to Swift 4.2. - [@babbage](https://github.com/babbage).
 
 ### 0.8.0 (11.10.2017)
 

--- a/FBSnapshotsViewer.xcodeproj/project.pbxproj
+++ b/FBSnapshotsViewer.xcodeproj/project.pbxproj
@@ -887,10 +887,12 @@
 					6D4724B81E3E9F2300F38161 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = Y4283X45U8;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Manual;
 					};
 					6D4724C91E3E9F2400F38161 = {
 						CreatedOnToolsVersion = 8.2.1;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 6D4724B81E3E9F2300F38161;
 					};
@@ -1366,7 +1368,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -1388,7 +1391,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "a4a82d49-55f8-4d42-b85b-8aa3a7c0a500";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -1406,7 +1410,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.antondomashnev.FBSnapshotsViewerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FBSnapshotsViewer.app/Contents/MacOS/FBSnapshotsViewer";
 			};
 			name = Debug;
@@ -1425,7 +1430,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.antondomashnev.FBSnapshotsViewerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FBSnapshotsViewer.app/Contents/MacOS/FBSnapshotsViewer";
 			};
 			name = Release;

--- a/FBSnapshotsViewer/AppDelegate.swift
+++ b/FBSnapshotsViewer/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let cofiguration = setUpConfiguration()
         let wireframe = MenuWireframe()
-        menuUserInterface = wireframe.instantinateMenu(in: NSStatusBar.system(), configuration: cofiguration)
+        menuUserInterface = wireframe.instantinateMenu(in: NSStatusBar.system, configuration: cofiguration)
     }
     
     // MARK: - Helpers

--- a/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
+++ b/FBSnapshotsViewer/Managers/SnapshotTestResultAcceptor.swift
@@ -29,17 +29,21 @@ class SnapshotTestResultAcceptor {
     
     private func buildRecordedImageURL(from imagePath: String, of testResult: SnapshotTestResult) throws -> URL {
         guard let failedImageSizeSuffixRange = imagePath.range(of: "@\\d{1}x", options: .regularExpression) else {
-                throw SnapshotTestResultAcceptorError.nonRetinaImages(testResult: testResult)
+            throw SnapshotTestResultAcceptorError.nonRetinaImages(testResult: testResult)
         }
-        let failedImageSizeSuffix = imagePath.substring(with: failedImageSizeSuffixRange)
-        let recordedImageURLs = testResult.build.fbReferenceImageDirectoryURLs.flatMap { fbReferenceImageDirectoryURL -> URL? in
-            let url = fbReferenceImageDirectoryURL.appendingPathComponent(testResult.testClassName).appendingPathComponent("\(testResult.testName)\(failedImageSizeSuffix)").appendingPathExtension("png")
-            return fileManager.fileExists(atPath: url.path) ? url : nil
+        let failedImageSizeSuffix = String(imagePath[failedImageSizeSuffixRange])
+        let recordedImageURLs = testResult.build.fbReferenceImageDirectoryURLs.compactMap { fbReferenceImageDirectoryURL -> URL? in
+            return urlForFailedReferenceImage(of: testResult, from: fbReferenceImageDirectoryURL, sizeSuffix: failedImageSizeSuffix)
         }
         guard let url = recordedImageURLs.first else {
             throw SnapshotTestResultAcceptorError.notExistedRecordedImage(testResult: testResult)
         }
         return url
+    }
+    
+    private func urlForFailedReferenceImage(of testResult: SnapshotTestResult, from referenceImageDirectoryURL: URL, sizeSuffix: String) -> URL? {
+        let url = referenceImageDirectoryURL.appendingPathComponent(testResult.testClassName).appendingPathComponent("\(testResult.testName)\(sizeSuffix)").appendingPathExtension("png")
+        return fileManager.fileExists(atPath: url.path) ? url : nil
     }
     
     // MARK: - Interface

--- a/FBSnapshotsViewer/Menu/User Interface/MenuController.swift
+++ b/FBSnapshotsViewer/Menu/User Interface/MenuController.swift
@@ -13,13 +13,13 @@ final class MenuController {
     var eventHandler: MenuModuleInterface?
 
     init(statusBar: NSStatusBar) {
-        statusItem = statusBar.statusItem(withLength: NSSquareStatusItemLength)
+        statusItem = statusBar.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem.button {
             button.image = NSImage(named: "menu_icon")
             button.alternateImage = NSImage(named: "menu_icon_highlighted")
             button.action = #selector(showSnapshots(sender:))
             button.target = self
-            button.sendAction(on: NSEventMask.leftMouseUp.union(NSEventMask.rightMouseUp))
+            button.sendAction(on: NSEvent.EventTypeMask.leftMouseUp.union(NSEvent.EventTypeMask.rightMouseUp))
         }
     }
 }
@@ -40,10 +40,10 @@ extension MenuController: MenuUserInterface {
 extension MenuController: MenuActions {
     func handleIconMouseEvent(_ event: NSEvent) {
         let associatedEventsMask = event.associatedEventsMask
-        if associatedEventsMask.contains(NSEventMask.rightMouseUp) {
+        if associatedEventsMask.contains(NSEvent.EventTypeMask.rightMouseUp) {
             eventHandler?.showApplicationMenu()
         }
-        else if associatedEventsMask.contains(NSEventMask.leftMouseUp) {
+        else if associatedEventsMask.contains(NSEvent.EventTypeMask.leftMouseUp) {
             eventHandler?.showTestResults()
         }
     }

--- a/FBSnapshotsViewer/Preferences/User Interface/PreferencesController.swift
+++ b/FBSnapshotsViewer/Preferences/User Interface/PreferencesController.swift
@@ -18,7 +18,7 @@ class PreferencesController: NSViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        NotificationCenter.default.addObserver(self, selector: #selector(derivedDataPathTextFieldDidChange(notification:)), name: Notification.Name.NSControlTextDidChange, object: derivedDataPathTextField)
+        NotificationCenter.default.addObserver(self, selector: #selector(derivedDataPathTextFieldDidChange(notification:)), name: NSControl.textDidChangeNotification, object: derivedDataPathTextField)
     }
 
     deinit {

--- a/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractor.swift
+++ b/FBSnapshotsViewer/Test Results/Interactor/TestResultsInteractor.swift
@@ -17,7 +17,7 @@ class TestResultsInteractorBuilder {
     var externalViewers: ExternalViewers = ExternalViewers()
     var processLauncher: ProcessLauncher = ProcessLauncher()
     var acceptor: SnapshotTestResultAcceptor = SnapshotTestResultAcceptor()
-    var pasteboard: Pasteboard = NSPasteboard.general()
+    var pasteboard: Pasteboard = NSPasteboard.general
     var testResults: [SnapshotTestResult] = []
     
     typealias BuiderClojure = (TestResultsInteractorBuilder) -> Void

--- a/FBSnapshotsViewer/Test Results/Presenter/TestResultsCollectionViewOutlets.swift
+++ b/FBSnapshotsViewer/Test Results/Presenter/TestResultsCollectionViewOutlets.swift
@@ -18,8 +18,8 @@ class TestResultsCollectionViewOutlets: NSObject {
               let testResultHeaderNib = NSNib(nibNamed: TestResultsHeader.itemIdentifier, bundle: Bundle.main) else {
             fatalError("TestResultCell || TestResultsHeader is missing in bundle")
         }
-        collectionView.register(testResultCellNib, forItemWithIdentifier: TestResultCell.itemIdentifier)
-        collectionView.register(testResultHeaderNib, forSupplementaryViewOfKind: NSCollectionElementKindSectionHeader, withIdentifier: TestResultsHeader.itemIdentifier)
+        collectionView.register(testResultCellNib, forItemWithIdentifier: NSUserInterfaceItemIdentifier(rawValue: TestResultCell.itemIdentifier))
+        collectionView.register(testResultHeaderNib, forSupplementaryViewOfKind: NSCollectionView.elementKindSectionHeader, withIdentifier: NSUserInterfaceItemIdentifier(rawValue: TestResultsHeader.itemIdentifier))
         self.testResultCellDelegate = testResultCellDelegate
         self.testResultsHeaderDelegate = testResultsHeaderDelegate
         super.init()
@@ -31,8 +31,8 @@ extension TestResultsCollectionViewOutlets: NSCollectionViewDelegateFlowLayout {
         return NSSize(width: 732, height: 408)
     }
 
-    func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, insetForSectionAt section: Int) -> EdgeInsets {
-        return EdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, insetForSectionAt section: Int) -> NSEdgeInsets {
+        return NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     }
     
     func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
@@ -58,7 +58,7 @@ extension TestResultsCollectionViewOutlets: NSCollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: NSCollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> NSView {
-        guard let view = collectionView.makeSupplementaryView(ofKind: NSCollectionElementKindSectionHeader, withIdentifier: TestResultsHeader.itemIdentifier, for: indexPath) as? TestResultsHeader else {
+        guard let view = collectionView.makeSupplementaryView(ofKind: NSCollectionView.elementKindSectionHeader, withIdentifier: NSUserInterfaceItemIdentifier(rawValue: TestResultsHeader.itemIdentifier), for: indexPath) as? TestResultsHeader else {
             fatalError("TestResultsHeader is not registered in collection view")
         }
         let sectionInfo = testResultsDisplayInfo.sectionInfos[indexPath.section]
@@ -68,7 +68,7 @@ extension TestResultsCollectionViewOutlets: NSCollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
-        guard let item = collectionView.makeItem(withIdentifier: TestResultCell.itemIdentifier, for: indexPath) as? TestResultCell else {
+        guard let item = collectionView.makeItem(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: TestResultCell.itemIdentifier), for: indexPath) as? TestResultCell else {
             fatalError("TestResultCell is not registered in collection view")
         }
         let testResultInfo = testResultsDisplayInfo.sectionInfos[indexPath.section].itemInfos[indexPath.item]

--- a/FBSnapshotsViewer/Test Results/Presenter/TestResultsDisplayInfosCollector.swift
+++ b/FBSnapshotsViewer/Test Results/Presenter/TestResultsDisplayInfosCollector.swift
@@ -29,9 +29,9 @@ class TestResultsDisplayInfosCollector {
     
     private func createSectionDisplayInfos(with groupedTestResults: [TestResultsSectionTitleDisplayInfo: [TestResultDisplayInfo]]) -> [TestResultsSectionDisplayInfo] {
         return groupedTestResults.map { TestResultsSectionDisplayInfo(title: $0.key, items: $0.value) }.sorted {
-            let timeAgo1 = $0.0.titleInfo.timeAgoDate
-            let timeAgo2 = $0.1.titleInfo.timeAgoDate
-            return timeAgo1 != timeAgo2 ? timeAgo1 >= timeAgo2 : $0.0.titleInfo.title > $0.1.titleInfo.title
+            let timeAgo1 = $0.titleInfo.timeAgoDate
+            let timeAgo2 = $1.titleInfo.timeAgoDate
+            return timeAgo1 != timeAgo2 ? timeAgo1 >= timeAgo2 : $0.titleInfo.title > $1.titleInfo.title
         }
     }
     

--- a/FBSnapshotsViewer/Test Results/User Interface/TestResultSplitView.swift
+++ b/FBSnapshotsViewer/Test Results/User Interface/TestResultSplitView.swift
@@ -33,7 +33,7 @@ class TestResultSplitView: NSView {
     // MARK: - Helpers
     
     private func createTrackingArea() {
-        trackingArea = NSTrackingArea(rect: bounds, options: NSTrackingAreaOptions.mouseEnteredAndExited.union(NSTrackingAreaOptions.mouseMoved).union(NSTrackingAreaOptions.activeAlways), owner: self, userInfo: nil)
+        trackingArea = NSTrackingArea(rect: bounds, options: NSTrackingArea.Options.mouseEnteredAndExited.union(NSTrackingArea.Options.mouseMoved).union(NSTrackingArea.Options.activeAlways), owner: self, userInfo: nil)
         self.addTrackingArea(trackingArea)
     }
     

--- a/FBSnapshotsViewerTests/MenuControllerSpec.swift
+++ b/FBSnapshotsViewerTests/MenuControllerSpec.swift
@@ -12,9 +12,9 @@ import Nimble
 @testable import FBSnapshotsViewer
 
 class MenuController_MockNSEvent: NSEvent {
-    var mockedAssociatedEventsMask: NSEventMask!
+    var mockedAssociatedEventsMask: NSEvent.EventTypeMask!
 
-    override var associatedEventsMask: NSEventMask {
+    override var associatedEventsMask: NSEvent.EventTypeMask {
         return mockedAssociatedEventsMask
     }
 }
@@ -53,7 +53,7 @@ class MenuController_MockStatusBar: NSStatusBar {
         return mockedStatusItem
     }
 
-    open override class func system() -> MenuController_MockStatusBar {
+    open override class var system: MenuController_MockStatusBar {
         return MenuController_MockStatusBar()
     }
 }
@@ -70,7 +70,7 @@ class MenuControllerSpec: QuickSpec {
             eventHandler = MenuModuleInterfaceMock()
             button = MenuController_MockNSStatusBarButton()
             statusItem = MenuController_MockNSStatusItem()
-            statusBar = MenuController_MockStatusBar.system()
+            statusBar = MenuController_MockStatusBar.system
             statusBar.mockedStatusItem = statusItem
             statusItem.mockedButton = button
             menuController = MenuController(statusBar: statusBar)
@@ -111,7 +111,7 @@ class MenuControllerSpec: QuickSpec {
             context("when rightMouseUp") {
                 beforeEach {
                     let event = MenuController_MockNSEvent()
-                    event.mockedAssociatedEventsMask = NSEventMask.rightMouseUp
+                    event.mockedAssociatedEventsMask = NSEvent.EventTypeMask.rightMouseUp
                     menuController.handleIconMouseEvent(event)
                 }
 
@@ -123,7 +123,7 @@ class MenuControllerSpec: QuickSpec {
             context("when leftMouseUp") {
                 beforeEach {
                     let event = MenuController_MockNSEvent()
-                    event.mockedAssociatedEventsMask = NSEventMask.leftMouseUp
+                    event.mockedAssociatedEventsMask = NSEvent.EventTypeMask.leftMouseUp
                     menuController.handleIconMouseEvent(event)
                 }
 

--- a/FBSnapshotsViewerTests/MenuWireframeSpec.swift
+++ b/FBSnapshotsViewerTests/MenuWireframeSpec.swift
@@ -24,7 +24,7 @@ class MenuWireframeSpec: QuickSpec {
             var menuModule: MenuController!
 
             beforeEach {
-                menuModule = wireframe.instantinateMenu(in: NSStatusBar.system(), configuration: Configuration.default()) as? MenuController
+                menuModule = wireframe.instantinateMenu(in: NSStatusBar.system, configuration: Configuration.default()) as? MenuController
             }
 
             it("returns initialized module") {

--- a/FBSnapshotsViewerTests/TestResultsWireframeSpec.swift
+++ b/FBSnapshotsViewerTests/TestResultsWireframeSpec.swift
@@ -30,7 +30,7 @@ class TestResultsWireframeSpec: QuickSpec {
                 rect = NSRect(x: 0, y: 0, width: 300, height: 300)
                 view = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 200))
                 view.wantsLayer = true
-                self.window = NSWindow(contentRect: rect, styleMask: NSWindowStyleMask.borderless, backing: .retained, defer: false)
+                self.window = NSWindow(contentRect: rect, styleMask: NSWindow.StyleMask.borderless, backing: .retained, defer: false)
                 self.window?.contentView?.addSubview(view)
             }
 

--- a/Vendor/SwiftGen/Fonts.swift
+++ b/Vendor/SwiftGen/Fonts.swift
@@ -24,7 +24,7 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
         let extensions = ["otf", "ttf"]
         let bundle = Bundle(for: BundleToken.self)
         
-        guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else { return }
+        guard let url = extensions.compactMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else { return }
         
         var errorRef: Unmanaged<CFError>?
         CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
@@ -40,7 +40,7 @@ extension Font {
                     font.register()
                 }
             #elseif os(OSX)
-                if NSFontManager.shared().availableMembers(ofFontFamily: font.rawValue) == nil {
+                if NSFontManager.shared.availableMembers(ofFontFamily: font.rawValue) == nil {
                     font.register()
                 }
             #endif


### PR DESCRIPTION
Migrates FBSnapshotsViewer and FBSnapshotsViewerTests to Swift 4.2.

It is no longer necessary for dependencies to be on the same version of Swift as the primary project. This migrates the main project, and lays the groundwork for integration of the forthcoming releases of Nimble/Quick (v8.0), and Nuke, which are in the process of migrating to Swift 4.2.